### PR TITLE
[AC-4788] Adding migration to appease Django 1.8.

### DIFF
--- a/accelerator/migrations/0003_appease_django_18.py
+++ b/accelerator/migrations/0003_appease_django_18.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import re
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accelerator', '0002_avoid_direct_use_of_simpleuser'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='startup',
+            name='url_slug',
+            field=models.CharField(default='',
+                                   unique=True,
+                                   max_length=64,
+                                   blank=True,
+                                   validators=[django.core.validators.RegexValidator('.*\\D.*', 'Slug must contain a non-numeral.'),
+                                               django.core.validators.RegexValidator(re.compile('^[-a-zA-Z0-9_]+\\Z'), "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.", 'invalid')]),
+        ),
+    ]


### PR DESCRIPTION
Django 1.8 seems to want this migration, but Django 1.10 doesn't seem to care one way or another.  This is needed to avoid warnings in accelerate.