### PR TITLE
[AC-4819] - Set up Travis for django-accelerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,7 @@ before_script:
 
 script:
 - make test
-- make code-check
+- git diff --name-only development | grep __init__.py | \
+  grep accelerator | xargs pep8 --filename accelerator/ --ignore E902; \
+  git diff --name-only development | grep accelerator | grep "\.py" | \
+  grep -v __init__.py | xargs flake8 --filename accelerator/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: python
 python:
   - "2.7"
   - "3.6"
-    # PyPy versions
-  - "pypy"
-  - "pypy3"
 cache: pip
 
 
@@ -25,5 +22,5 @@ before_script:
 
 
 script:
-- make tox
+- make test
 - make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ before_script:
 
 script:
 - make test
-- make code-check
+#- make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ before_script:
 - echo $TRAVIS_PULL_REQUEST_BRANCH
 - echo $TRAVIS_PULL_REQUEST
 - echo $BRANCH
-- git remote set-branches origin $BRANCH
-- git fetch
-- git checkout $BRANCH
+- export CURRENT_HEAD=$(git rev-parse HEAD)
+- git checkout -b development|| git checkout development
+- git pull origin development
+- git checkout $CURRENT_HEAD
 - git diff --name-only HEAD...$TRAVIS_BRANCH
 - git diff --name-only development
 
 script:
 - make test
-#- make code-check
+- make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ services:
 
 install:
 - make install
-
-
-#before_script:
-
-script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - echo $TRAVIS_BRANCH
 - echo $TRAVIS_PULL_REQUEST_BRANCH
@@ -27,5 +22,10 @@ script:
 - git checkout -b $BRANCH || git checkout $BRANCH
 - git pull origin $BRANCH
 - git checkout $CURRENT_HEAD
+
+#before_script:
+
+script:
+
 - make test
 - make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ install:
 - git pull origin $BRANCH
 - git checkout $CURRENT_HEAD
 
-#before_script:
-
 script:
 
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ before_script:
 - echo $TRAVIS_PULL_REQUEST
 - echo $BRANCH
 - export CURRENT_HEAD=$(git rev-parse HEAD)
-- git checkout -b development|| git checkout development
+- git checkout -b development || git checkout development
 - git pull origin development
+- git checkout -b $BRANCH || git checkout $BRANCH
+- git pull origin $BRANCH
 - git checkout $CURRENT_HEAD
-- git diff --name-only HEAD...$TRAVIS_BRANCH
-- git diff --name-only development
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
 sudo: false
 dist: trusty
 language: python
+python:
+  - "2.7"
+  - "3.6"
+    # PyPy versions
+  - "pypy"
+  - "pypy3"
+cache: pip
+
+
 services:
 - mysql
 
 install:
 - make install
+
+
+before_script:
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+- git remote set-branches origin $BRANCH
+- git fetch
+- git checkout $BRANCH
+
 
 script:
 - make tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_script:
 - git remote set-branches origin $BRANCH
 - git fetch
 - git checkout $BRANCH
-
+- git diff --name-only HEAD...$TRAVIS_BRANCH
+- git diff --name-only development
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+dist: trusty
+language: python
+services:
+- mysql
+
+install:
+- make install
+
+script:
+- make tox
+- make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,4 @@ before_script:
 
 script:
 - make test
-- git diff --name-only development | grep __init__.py | \
-  grep accelerator | xargs pep8 --filename accelerator/ --ignore E902; \
-  git diff --name-only development | grep accelerator | grep "\.py" | \
-  grep -v __init__.py | xargs flake8 --filename accelerator/
+- make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
-sudo: false
+sudo: required
 dist: trusty
 language: python
 python:
   - "2.7"
   - "3.6"
 cache: pip
-
 
 services:
 - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ install:
 - make install
 
 
-before_script:
+#before_script:
+
+script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - echo $TRAVIS_BRANCH
 - echo $TRAVIS_PULL_REQUEST_BRANCH
@@ -25,7 +27,5 @@ before_script:
 - git checkout -b $BRANCH || git checkout $BRANCH
 - git pull origin $BRANCH
 - git checkout $CURRENT_HEAD
-
-script:
 - make test
 - make code-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ install:
 
 before_script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+- echo $TRAVIS_BRANCH
+- echo $TRAVIS_PULL_REQUEST_BRANCH
+- echo $TRAVIS_PULL_REQUEST
+- echo $BRANCH
 - git remote set-branches origin $BRANCH
 - git fetch
 - git checkout $BRANCH

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ clean:
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	grep accelerator | xargs pep8 --ignore E902; \
+	grep accelerator | xargs pep8 --filename accelerator/ --ignore E902; \
 	git diff --name-only development | grep accelerator | grep "\.py" | \
-	  grep -v __init__.py | xargs flake8
+	  grep -v __init__.py | xargs flake8 --filename accelerator/
 
 coverage: coverage-run coverage-report coverage-html
 

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ clean:
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	grep -v venv | xargs pep8 --ignore E902; \
-	git diff --name-only development | grep "\.py" | \
-	  grep -v __init__.py | grep -v venv | xargs flake8
+	grep accelerator | xargs pep8 --ignore E902; \
+	git diff --name-only development | grep accelerator | grep "\.py" | \
+	  grep -v __init__.py | xargs flake8
 
 coverage: coverage-run coverage-report coverage-html
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ target_help = \
   "Note: various targets automatically create a python virtualenv, venv." \
   "You can us it in your shell by running: 'source venv/bin/activate'"
 
+OS = $(shell uname)
+
+ifeq ($(OS), Linux)
+	XARGS_FLAG = -r
+endif
 
 ENVIRONMENT_NAME = venv
 SETUP_ENV = $(ENVIRONMENT_NAME)/bin/activate
@@ -65,12 +70,14 @@ $(SETUP_ENV):
 clean:
 	@rm -rf venv django_accelerator.egg-info dist
 
+
+
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	grep accelerator | xargs -r pep8 --filename accelerator/ --ignore E902; \
+	grep accelerator | xargs $(XARGS_FLAG) pep8 --filename accelerator/ --ignore E902; \
 	git diff --name-only development | grep accelerator | grep "\.py" | \
-	  grep -v __init__.py | xargs -r flake8 --filename accelerator/
+	  grep -v __init__.py | xargs $(XARGS_FLAG) flake8 --filename accelerator/
 
 coverage: coverage-run coverage-report coverage-html
 

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ clean:
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	grep accelerator | xargs pep8 --filename accelerator/ --ignore E902; \
+	grep accelerator | xargs -r pep8 --filename accelerator/ --ignore E902; \
 	git diff --name-only development | grep accelerator | grep "\.py" | \
-	  grep -v __init__.py | xargs flake8 --filename accelerator/
+	  grep -v __init__.py | xargs -r flake8 --filename accelerator/
 
 coverage: coverage-run coverage-report coverage-html
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ clean:
 
 
 code-check: $(SETUP_ENV)
-	-@. $(SETUP_ENV); \
+	@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
 	grep accelerator | xargs $(XARGS_FLAG) pep8 --filename accelerator/ --ignore E902; \
 	git diff --name-only development | grep accelerator | grep "\.py" | \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean:
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	  | grep -v venv | xargs pep8 --ignore E902; \
+	grep -v venv | xargs pep8 --ignore E902; \
 	git diff --name-only development | grep "\.py" | \
 	  grep -v __init__.py | grep -v venv | xargs flake8
 

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,10 @@ coverage: coverage-run coverage-report coverage-html
 coverage-run:
 	@. $(SETUP_ENV); DJANGO_SETTINGS_MODULE=settings coverage run --omit="*/tests/*,*/venv/*" --source='.' /usr/local/bin/django-admin.py test
 
-coverage-report: DIFFBRANCH?=$(shell if [ "${BRANCH}" == "" ]; \
-   then echo "development"; else echo "${BRANCH}"; fi;)
-coverage-report: diff_files:=$(shell git diff --name-only $(DIFFBRANCH))
+
+BRANCH ?= development
+
+coverage-report: diff_files:=$(shell git diff --name-only $(BRANCH))
 coverage-report: diff_sed:=$(shell echo $(diff_files)| sed s:web/impact/::g)
 coverage-report: diff_grep:=$(shell echo $(diff_sed) | tr ' ' '\n' | grep \.py | grep -v /tests/ | grep -v /venv/ | grep -v /django_migrations/ | tr '\n' ' ' )
 coverage-report:

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ clean:
 code-check: $(SETUP_ENV)
 	-@. $(SETUP_ENV); \
 	git diff --name-only development | grep __init__.py | \
-	  xargs pep8 --ignore E902; \
+	  | grep -v venv | xargs pep8 --ignore E902; \
 	git diff --name-only development | grep "\.py" | \
-	  grep -v __init__.py | xargs flake8
+	  grep -v __init__.py | grep -v venv | xargs flake8
 
 coverage: coverage-run coverage-report coverage-html
 

--- a/accelerator/models/__init__.py
+++ b/accelerator/models/__init__.py
@@ -10,8 +10,8 @@ from .job_posting import (
 from .organization import Organization
 from .recommendation_tag import RecommendationTag
 from .startup import (
-    Startup,
-    STARTUP_COMMUNITIES,
     DEFAULT_PROFILE_BACKGROUND_COLOR,
     DEFAULT_PROFILE_TEXT_COLOR,
+    Startup,
+    STARTUP_COMMUNITIES,
 )

--- a/accelerator/test_runner.py
+++ b/accelerator/test_runner.py
@@ -21,8 +21,6 @@ class UnManagedModelTestRunner(DiscoverRunner):
             UnManagedModelTestRunner,
             self).setup_test_environment(*args, **kwargs)
 
-
-
     def teardown_test_environment(self, *args, **kwargs):
         super(
             UnManagedModelTestRunner,

--- a/accelerator/test_runner.py
+++ b/accelerator/test_runner.py
@@ -21,6 +21,8 @@ class UnManagedModelTestRunner(DiscoverRunner):
             UnManagedModelTestRunner,
             self).setup_test_environment(*args, **kwargs)
 
+
+
     def teardown_test_environment(self, *args, **kwargs):
         super(
             UnManagedModelTestRunner,


### PR DESCRIPTION
**Changes Introduced in [AC-4819](https://masschallenge.atlassian.net/browse/AC-4819):**

- add travis.yml file for django-accelerator.
- adjust makefile such that `make code-check` works correctly in travis.

**Test:**
- Introduce a failing test, push it. See that travis is failing on PR and PUSH.
- Fix that test, introduce a style failure, push it. See that travis is failing in PR but passing in PUSH.
- Fix that style failure, push it. See that travis succeeds.
- Locally, `make code-check` is working as expected.

**Note:**
- Each commit triggers 4 builds - twice for each of [PR, PUSH], one for Python 2.7 and one for 3.6.
- There's a known bug in the travis log output, as described in [AC-4869](https://masschallenge.atlassian.net/browse/AC-4869). I'd love this to be reviewed as part of this PR.
- Feel free to look on earlier builds, if you care, but only the last two are there for the final definitive demonstration.

