### PR TITLE
[AC-5175] pin django-accelerate's Django version below 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-DJANGO_SPEC = ">=1.8"
+DJANGO_SPEC = ">=1.8,<2.0"
 if "DJANGO_VERSION" in os.environ:
     DJANGO_SPEC = "=={}".format(os.environ["DJANGO_VERSION"])
 


### PR DESCRIPTION
## [AC-5175](https://masschallenge.atlassian.net/browse/AC-5175)

Builds of django-accelerator `development` on Python 2.7  currently failThis problem arose because at the time we specified `Django>=1.8` as a requirement, the highest release of Django was less than 2.0. **Then 2.0 was released!**

The development branch hasn't had a Travis build in a month, that's how we missed this.

**TO TEST**
* Confirm that [Travis build for this branch](https://travis-ci.org/masschallenge/django-accelerator/builds/315007712) does not fail; the [Python 2.7 build on the development branch](https://travis-ci.org/masschallenge/django-accelerator/builds/298783595) does.