### PR TITLE
[AC-5478] fix __str__ call causing bottomless recursion

### DIFF
--- a/accelerator_abstract/models/accelerator_model.py
+++ b/accelerator_abstract/models/accelerator_model.py
@@ -17,5 +17,4 @@ class AcceleratorModel(models.Model):
         managed = settings.ACCELERATOR_MODELS_ARE_MANAGED
 
     def __str__(self):
-        return self.name if hasattr(self, 'name') else super(AcceleratorModel,
-                                                             self).__str__()
+        return self.name if hasattr(self, 'name') else repr(self)


### PR DESCRIPTION
## [AC-5478](https://masschallenge.atlassian.net/browse/AC-5478)

Given the urgency of this bug, I'm posting this PR even though we don't have a test yet. Existing tests all pass. At a minimum we should try running this code with the prod data on staging. Click on ticket number in heading above for more details.

My my grep/count, there are 14 models in `accelerator_abstract` that neither override the `__str__` method nor have a `name` field. These are the ones that will fall back to this parent method and benefit from this fix.

* base_startup_cycle_interest.py
* label_model.py
* base_category_header_page.py
* base_user_role_menu.py
* base_startup_attribute.py
* base_expert_profile.py
* base_member_profile.py
* base_paypal_refund.py
* base_site_redirect_page.py
* base_paypal_payment.py
* base_file_page.py
* base_entrepreneur_profile.py
* base_user_utils.py
* base_judge_availability.py
