### PR TITLE
[AC-5714] lock Pillow to 5.0.0 because of version issues

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ flake8
 tox
 mock
 factory-boy
+Pillow==5.0.0


### PR DESCRIPTION
Pillow 5.1.0 fails on OSX <10.12 because of XCode problems.
5.1.1 supposedly resolves this but is not available through
pip as yet.