### PR TITLE
[AC-5894] Explicitly use python3.6 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,11 @@ VENV = venv
 ACTIVATE_SCRIPT = $(VENV)/bin/activate
 ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)
 DJANGO_ADMIN = $(VENV)/bin/django-admin.py
+PYTHON_VERSION = python3.6
+ifeq ($(TRAVIS_PYTHON_VERSION), 2.7)
+	PYTHON_VERSION = python2.7
+endif
+
 
 $(VENV): requirements/base.txt requirements/dev.txt Makefile
 	@if [ ! python3.6 ]; then \
@@ -103,7 +108,7 @@ $(VENV): requirements/base.txt requirements/dev.txt Makefile
 	fi
 	@pip install virtualenv
 	@rm -rf $(VENV)
-	@virtualenv -p `which python3.6 || which python3` $@
+	@virtualenv -p `which $(PYTHON_VERSION)` $@
 	@touch $(ACTIVATE_SCRIPT)
 	@$(ACTIVATE) ; \
 	DJANGO_VERSION=$(DJANGO_VERSION) pip install -r requirements/dev.txt

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ endif
 
 
 $(VENV): requirements/base.txt requirements/dev.txt Makefile
-	@if [ ! python3.6 ]; then \
-		echo "You need to install python3.6 for this to work.."; exit 1; \
+	@if ! eval $(PYTHON_VERSION) --version ; then \
+		echo "You need to install $(PYTHON_VERSION) for this to work.."; exit 1; \
 	fi
 	@pip install virtualenv
 	@rm -rf $(VENV)

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,12 @@ ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)
 DJANGO_ADMIN = $(VENV)/bin/django-admin.py
 
 $(VENV): requirements/base.txt requirements/dev.txt Makefile
+	@if [ ! python3.6 ]; then \
+		echo "You need to install python3.6 for this to work.."; exit 1; \
+	fi
 	@pip install virtualenv
 	@rm -rf $(VENV)
-	@virtualenv -p `which python3` $@
+	@virtualenv -p `which python3.6 || which python3` $@
 	@touch $(ACTIVATE_SCRIPT)
 	@$(ACTIVATE) ; \
 	DJANGO_VERSION=$(DJANGO_VERSION) pip install -r requirements/dev.txt


### PR DESCRIPTION
#### Changes introduced in [AC-5894](https://masschallenge.atlassian.net/projects/AC/issues/AC-5894):
- Explicitly use python3.6 when running `make migrations`
- Add check and useful error message if python3.6 isn't installed

Background:

It was discovered that as much as the Makefile was pointing to `python3`, it may not be pointing to the correct version of python3 i.e. v3.6. Hence the change and extra check.
