### PR TITLE
[AC-5896] - Bug - Make sure `get_profile()` is available on impact-api

### DIFF
--- a/accelerator/apps.py
+++ b/accelerator/apps.py
@@ -6,3 +6,7 @@ from django.apps import AppConfig
 
 class AcceleratorConfig(AppConfig):
     name = 'accelerator'
+
+    def ready(self):
+        from accelerator_abstract.apps import add_get_profile_to_user_class
+        add_get_profile_to_user_class()

--- a/accelerator_abstract/apps.py
+++ b/accelerator_abstract/apps.py
@@ -3,15 +3,20 @@
 import swapper
 from django.apps import AppConfig
 from django.contrib.auth import get_user_model
+
 from accelerator.apps import AcceleratorConfig
+
+
+def add_get_profile_to_user_class():
+    User = get_user_model()
+    BaseProfile = swapper.load_model(AcceleratorConfig.name, 'BaseProfile')
+    User.add_to_class('get_profile',
+                      lambda user: BaseProfile.objects.get(
+                          email=user.email))
 
 
 class AcceleratorAbstractConfig(AppConfig):
     name = 'accelerator_abstract'
 
     def ready(self):
-        User = get_user_model()
-        BaseProfile = swapper.load_model(AcceleratorConfig.name, 'BaseProfile')
-        User.add_to_class('get_profile',
-                          lambda user: BaseProfile.objects.get(
-                              email=user.email))
+        add_get_profile_to_user_class()

--- a/accelerator_abstract/apps.py
+++ b/accelerator_abstract/apps.py
@@ -17,6 +17,3 @@ def add_get_profile_to_user_class():
 
 class AcceleratorAbstractConfig(AppConfig):
     name = 'accelerator_abstract'
-
-    def ready(self):
-        add_get_profile_to_user_class()


### PR DESCRIPTION
**Changes Introduced in [AC-5896](https://masschallenge.atlassian.net/browse/AC-5896):**
- add get_profile to user class on accelerator app as well.

**Test:**
- in impact-api, run `make django-shell`
run:
```
from accelerator.models import StartupMentorRelationship
StartupMentorRelationship.objects.first()
```
- on django-accelerator's development this fails, and succeeds on branch