### PR TITLE
[AC-5898] Eliminate naive datetime

### DIFF
--- a/accelerator/tests/factories/factory_utils.py
+++ b/accelerator/tests/factories/factory_utils.py
@@ -28,5 +28,5 @@ def expert_data(user, password="password"):
         "public_website_consent": True,
         "username": user.username,
         "password": password,
-        "date_joined": user.date_joined,
+        "date_joined": user.date_joined.date(),
     }

--- a/simpleuser/tests/factories/user_factory.py
+++ b/simpleuser/tests/factories/user_factory.py
@@ -30,7 +30,7 @@ class UserFactory(DjangoModelFactory):
     is_staff = False
     is_active = True
     last_login = timezone.now() + timedelta(-1)
-    date_joined = (timezone.now() + timedelta(-10)).date()
+    date_joined = timezone.now() + timedelta(-10)
 
     @classmethod
     def _prepare(cls, create, **kwargs):


### PR DESCRIPTION
Converting the `datetime` to a `date` strips tz info, causing a naive datetime to be created incorrectly.  
Came across this while working on a test for AC-5836, so fixed it. 

To test: 
check out impact-api, run tests. Note timezone warning
point impact-api at this branch, build, and run tests again. Note, no timezone warning