### PR TITLE
[AC-5853] Change context and StartupProgramInterestFactory

### DIFF
--- a/accelerator/tests/contexts/judge_feedback_context.py
+++ b/accelerator/tests/contexts/judge_feedback_context.py
@@ -268,7 +268,8 @@ class JudgeFeedbackContext:
         StartupProgramInterestFactory(program=program,
                                       startup=startup,
                                       startup_cycle_interest=cycle_interest,
-                                      applying=True)
+                                      applying=True,
+                                      interest_level=1)
 
     def add_applications(self, count, field=None, options=[], programs=[]):
         result = []

--- a/accelerator/tests/contexts/judge_feedback_context.py
+++ b/accelerator/tests/contexts/judge_feedback_context.py
@@ -107,7 +107,8 @@ class JudgeFeedbackContext:
         StartupProgramInterestFactory(program=self.program,
                                       startup=self.startup,
                                       startup_cycle_interest=cycle_interest,
-                                      applying=True)
+                                      applying=True,
+                                      interest_level=1)
         self.components = []
         self.elements = []
         self.application_questions = []

--- a/accelerator/tests/factories/startup_program_interest_factory.py
+++ b/accelerator/tests/factories/startup_program_interest_factory.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import swapper
 from factory import (
     DjangoModelFactory,
+    Sequence,
     SubFactory,
 )
 
@@ -28,4 +29,4 @@ class StartupProgramInterestFactory(DjangoModelFactory):
     startup = SubFactory(StartupFactory)
     startup_cycle_interest = SubFactory(StartupCycleInterestFactory)
     applying = False
-    interest_level = ""
+    interest_level = Sequence(lambda x: x)


### PR DESCRIPTION
Two changes here, a specific change to the context needed for AC-5853 (setting initial interest to 1) and a more general change to StartupProgramInterestFactory so that interest_level will always have an integer value by default. 

I have run tests on accelerate to verify that this change does not break any tests there. 

Note that this PR is a prerequisite for the tests in https://github.com/masschallenge/impact-api/pull/205