### PR TITLE
AC-6079: Refactor accelerate to use `is_employee` as a function from base_utils on django-accelerator

### DIFF
--- a/accelerator_abstract/models/base_user_utils.py
+++ b/accelerator_abstract/models/base_user_utils.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from __future__ import unicode_literals
+from accelerator_abstract.models import BaseUserRole
 
 
 def is_expert(user):
@@ -20,3 +21,10 @@ def _has_user_type(obj, user_type):
     return (obj and
             getattr(obj, "baseprofile", None) and
             obj.baseprofile.user_type == user_type)
+
+
+def is_employee(user):
+    return (user.is_superuser or
+            user.programrolegrant_set.filter(
+                program_role__user_role__name=BaseUserRole.STAFF
+            ).exists())


### PR DESCRIPTION
**Changes introduced in [AC-6079](https://masschallenge.atlassian.net/browse/AC-6079)**:
- add 'is_employee' function to django-accelerator base_user_utils