### PR TITLE
[AC-6320] Upgrade to Django 1.11.18 on accelerate and django-accelerator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ help:
 	@echo
 
 
-DJANGO_VERSION = 1.11.14
+DJANGO_VERSION = 1.11.18
 VENV = venv
 ACTIVATE_SCRIPT = $(VENV)/bin/activate
 ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)


### PR DESCRIPTION
## [AC-6320](https://masschallenge.atlassian.net/browse/AC-6320)

Testing instructions: try to find something that this breaks.

Also see the [accelerate PR](https://github.com/masschallenge/accelerate/pull/2023).