### PR TITLE
AC-6272: Update Judge Progress Stats for New Allocator

### DIFF
--- a/accelerator/tests/contexts/judge_feedback_context.py
+++ b/accelerator/tests/contexts/judge_feedback_context.py
@@ -11,7 +11,7 @@ from accelerator.models import (
     FEEDBACK_DISPLAY_ENABLED as ENABLED,
     IN_PERSON_JUDGING_ROUND_TYPE,
     ONLINE_JUDGING_ROUND_TYPE,
-
+    JUDGING_FEEDBACK_STATUS_INCOMPLETE as INCOMPLETE,
     PREVIEW_PANEL_STATUS,
     SUBMITTED_APP_STATUS,
     UserRole,
@@ -232,7 +232,8 @@ class JudgeFeedbackContext:
     def add_feedback(self,
                      application=None,
                      judge=None,
-                     panel=None):
+                     panel=None,
+                     feedback_status=INCOMPLETE):
         judge = judge or self.judge
         application = application or self.application
         panel = panel or self.panel
@@ -243,6 +244,7 @@ class JudgeFeedbackContext:
                 panel=panel,
                 scenario=self.scenario)
         return JudgeApplicationFeedbackFactory(
+            feedback_status=feedback_status,
             judge=judge,
             application=application,
             panel=panel,

--- a/accelerator/tests/factories/judge_application_feedback_factory.py
+++ b/accelerator/tests/factories/judge_application_feedback_factory.py
@@ -27,6 +27,7 @@ JudgeApplicationFeedback = swapper.load_model(AcceleratorConfig.name,
 class JudgeApplicationFeedbackFactory(DjangoModelFactory):
     class Meta:
         model = JudgeApplicationFeedback
+        django_get_or_create = ('application', 'judge', 'panel')
 
     application = SubFactory(ApplicationFactory)
     form_type = SubFactory(JudgingFormFactory)


### PR DESCRIPTION
#### Changes introduced in [AC-6272](https://masschallenge.atlassian.net/browse/AC-6272)
add unique together constraint to judge_application_feedback_factory and allow us change application feedback from judge_feedback_context

#### Context
- These changes are introduced to support a test in the [sibling PR](https://github.com/masschallenge/accelerate/pull/2064) on accelerate

#### Note
- This PR should be merged first as it has dependent tests
- This does not need to be merged in any particular order relative to other django-accelerator PRs since it does not introduce a migration