### PR TITLE
[AC-9350] Office Hours - Require location and add a default

### DIFF
--- a/accelerator/models/__init__.py
+++ b/accelerator/models/__init__.py
@@ -61,8 +61,6 @@ from accelerator_abstract.models.base_mentor_program_office_hour import (
     MC_IL_JLM_LOCATION,
     MC_OTHER_LOCATION,
     MC_MX_LOCATION,
-    MC_NIC_LOCATION,
-    MC_PULSE_LOCATION,
     MC_REMOTE_LOCATION,
 )
 from .program_override import ProgramOverride

--- a/accelerator_abstract/models/__init__.py
+++ b/accelerator_abstract/models/__init__.py
@@ -161,8 +161,6 @@ from .base_mentor_program_office_hour import (
     MC_IL_JLM_LOCATION,
     MC_OTHER_LOCATION,
     MC_MX_LOCATION,
-    MC_NIC_LOCATION,
-    MC_PULSE_LOCATION,
     MC_REMOTE_LOCATION,
 )
 from .base_mentoring_specialties import BaseMentoringSpecialties

--- a/accelerator_abstract/models/base_mentor_program_office_hour.py
+++ b/accelerator_abstract/models/base_mentor_program_office_hour.py
@@ -12,23 +12,23 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 MC_BOS_LOCATION = "MassChallenge Boston"
 MC_IL_JLM_LOCATION = "MassChallenge Israel - Jerusalem"
+MC_IL_TLV_LOCATION = "MassChallenge Israel - Tel Aviv"
 MC_MX_LOCATION = "MassChallenge Mexico"
 MC_RI_LOCATION = "MassChallenge Rhode Island"
 MC_CH_LOCATION = "MassChallenge Switzerland"
-MC_TX_LOCATION = "MassChallenge Texas"
-MC_NIC_LOCATION = "Newton Innovation Center (NIC)"
-MC_PULSE_LOCATION = "PULSE@MassChallenge"
+MC_TX_LOCATION = "MassChallenge Texas - Austin"
+MC_TXH_LOCATION = "MassChallenge Texas - Houston"
 MC_REMOTE_LOCATION = "Remote - see description"
 MC_OTHER_LOCATION = "Other - see description"
 LOCATION_CHOICES = (
     (MC_BOS_LOCATION, MC_BOS_LOCATION),
     (MC_IL_JLM_LOCATION, MC_IL_JLM_LOCATION),
+    (MC_IL_TLV_LOCATION, MC_IL_TLV_LOCATION),
     (MC_MX_LOCATION, MC_MX_LOCATION),
     (MC_RI_LOCATION, MC_RI_LOCATION),
     (MC_CH_LOCATION, MC_CH_LOCATION),
     (MC_TX_LOCATION, MC_TX_LOCATION),
-    (MC_NIC_LOCATION, MC_NIC_LOCATION),
-    (MC_PULSE_LOCATION, MC_PULSE_LOCATION),
+    (MC_TXH_LOCATION, MC_TXH_LOCATION),
     (MC_REMOTE_LOCATION, MC_REMOTE_LOCATION),
     (MC_OTHER_LOCATION, MC_OTHER_LOCATION),
 )


### PR DESCRIPTION
**Changes Introduced in [AC-9350](https://masschallenge.atlassian.net/browse/AC-9350):**
- Made the location field in the office hour creation mandatory
- Removed old locations and added new ones

**Test:**

_checkout this branch on both Accelerate and Django Accelerator Repos_
- Visit the Office Hours page and try to create a new Office Hour
- Notice that none of the valid locations is selected by default, submit without changing and see an alert
- Notice also that locations were added and removed as specified in the ticket.

NB: Sibling PR: https://github.com/masschallenge/accelerate/pull/2114