### PR TITLE
AC-6377: Build new people directory page in front-end repo (React + SUI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv
 
 # Emacs ~ files
 *~
+
+# image url test directory
+/profile_pics

--- a/accelerator/tests/contexts/startup_team_member_context.py
+++ b/accelerator/tests/contexts/startup_team_member_context.py
@@ -28,8 +28,8 @@ class StartupTeamMemberContext(object):
                  user=None,
                  upcoming=False,
                  startup_administrator=False,
-                 primary_contact=True):
-        program_status = ACTIVE_PROGRAM_STATUS
+                 primary_contact=True,
+                 program_status=ACTIVE_PROGRAM_STATUS):
         applications_open = False
         if upcoming:
             program_status = UPCOMING_PROGRAM_STATUS

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -7,15 +7,210 @@ from django.test import TestCase
 
 from accelerator.tests.factories import (
     ExpertFactory,
+    InterestCategoryFactory,
+    MemberFactory,
+    ProgramFactory,
+    ProgramRoleFactory,
+    ProgramRoleGrantFactory,
+    StartupFactory,
+    UserRoleFactory,
+    ProgramFamilyFactory,
+    PartnerTeamMemberFactory
 )
+from accelerator_abstract.models import (
+    BaseUserRole
+)
+from accelerator.tests.contexts import StartupTeamMemberContext
+
+
+def expert(role):
+    user = ExpertFactory()
+    profile = user.get_profile()
+    profile.gender = 'm'
+    profile.save()
+    ur = UserRoleFactory(name=role)
+    pr = ProgramRoleFactory.create(user_role=ur)
+    ProgramRoleGrantFactory.create(person=user, program_role=pr)
+    return user
 
 
 class TestCoreProfile(TestCase):
     def test_full_name(self):
         user = ExpertFactory(first_name="", last_name="")
-        assert user.get_profile().full_name() == str(user.email)
+        self.assertTrue(user.get_profile().full_name() == str(user.email))
 
     def test_str(self):
         user = ExpertFactory()
         profile = user.get_profile()
-        assert profile.full_name() in str(profile)
+        self.assertTrue(profile.full_name() in str(profile))
+
+    def test_mentor_is_office_hour_holder(self):
+        user = expert(BaseUserRole.MENTOR)
+        self.assertTrue(user.get_profile().is_office_hour_holder())
+
+    def test_partner_is_office_hour_holder(self):
+        user = expert(BaseUserRole.PARTNER)
+        self.assertTrue(user.get_profile().is_office_hour_holder())
+
+    def test_partner_admin_is_office_hour_holder(self):
+        user = expert(BaseUserRole.PARTNER_ADMIN)
+        self.assertTrue(user.get_profile().is_office_hour_holder())
+
+    def test_alumni_in_residence_is_office_hour_holder(self):
+        user = expert(BaseUserRole.AIR)
+        self.assertTrue(user.get_profile().is_office_hour_holder())
+
+    def test_user_roles(self):
+        user = ExpertFactory()
+        user_role_names = [BaseUserRole.MENTOR,
+                           BaseUserRole.STAFF,
+                           BaseUserRole.AIR]
+        for role_name in user_role_names:
+            ur = UserRoleFactory(name=role_name)
+            pr1 = ProgramRoleFactory.create(name=role_name + "1",
+                                            user_role=ur)
+            pr2 = ProgramRoleFactory.create(name=role_name + "2",
+                                            user_role=ur)
+            ProgramRoleGrantFactory.create(person=user,
+                                           program_role=pr1)
+            ProgramRoleGrantFactory.create(person=user,
+                                           program_role=pr2)
+        self.assertTrue(len(user.get_profile().user_roles()) ==
+                        len(user_role_names))
+
+    def test_active_alerts(self):
+        member = MemberFactory()
+        self.assertTrue(len(member.get_profile().get_active_alerts()) == 0)
+
+    def test_is_judge_is_false_by_default(self):
+        user = expert(BaseUserRole.FINALIST)
+        self.assertFalse(user.get_profile().is_judge())
+
+    def test_is_alum_is_false_by_default(self):
+        user = expert(BaseUserRole.FINALIST)
+        self.assertFalse(user.get_profile().is_alum())
+
+    def test_first_startup_is_false_by_default(self):
+        user = expert(BaseUserRole.FINALIST)
+        self.assertFalse(user.get_profile().first_startup())
+
+    def test_gender_value_is_male(self):
+        user = expert(BaseUserRole.FINALIST)
+        profile = user.get_profile()
+        self.assertTrue(profile.gender_value() == "Male")
+
+    def test_program_family_names(self):
+        user = expert(BaseUserRole.FINALIST)
+        profile = user.get_profile()
+        family = ProgramFamilyFactory()
+        profile.program_families.add(family)
+        self.assertTrue(profile.program_family_names() == [family.name])
+
+    def test_interest_category_names(self):
+        user = expert(BaseUserRole.FINALIST)
+        profile = user.get_profile()
+        interest_category = InterestCategoryFactory()
+        profile.interest_categories.add(interest_category)
+        self.assertTrue(
+            profile.interest_category_names() == [interest_category.name])
+
+    def test_is_alum_in_residence(self):
+        user = expert(BaseUserRole.AIR)
+        profile = user.get_profile()
+        self.assertTrue(profile.is_alum_in_residence())
+
+    def test_is_partner(self):
+        user = expert(BaseUserRole.FINALIST)
+        PartnerTeamMemberFactory(team_member=user)
+        profile = user.get_profile()
+        self.assertTrue(profile.is_partner())
+
+    def test_is_partner_admin(self):
+        user = expert(BaseUserRole.FINALIST)
+        PartnerTeamMemberFactory(
+            team_member=user, partner_administrator=True)
+        profile = user.get_profile()
+        self.assertTrue(profile.is_partner_admin())
+
+    def test_is_mentor(self):
+        user = expert(BaseUserRole.MENTOR)
+        profile = user.get_profile()
+        self.assertTrue(profile.is_mentor())
+
+    def test_is_mentor_with_program_passed_in(self):
+        user = expert(BaseUserRole.MENTOR)
+        profile = user.get_profile()
+        self.assertFalse(profile.is_mentor(ProgramFactory()))
+
+    def test_startup_based_landing_page(self):
+        page = "/asante"
+        startup = StartupFactory(landing_page=page)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup=startup)
+        profile = context.user.get_profile()
+        self.assertTrue(profile.startup_based_landing_page() == page)
+
+    def test_startup_based_landing_page_returns_none_without_landpage(self):
+        context = StartupTeamMemberContext(
+            primary_contact=False)
+        profile = context.user.get_profile()
+        self.assertTrue(profile.startup_based_landing_page() is None)
+
+    def test_check_landing_page(self):
+        page = "/asante"
+        startup = StartupFactory(landing_page=page)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup=startup)
+        profile = context.user.get_profile()
+        self.assertTrue(profile.check_landing_page() == page)
+
+    def test_check_landing_page_with_landing_page_as_root(self):
+        page = "/"
+        startup = StartupFactory(landing_page=page)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup=startup)
+        profile = context.user.get_profile()
+        self.assertTrue(
+            profile.check_landing_page() == profile.default_page)
+
+    def test_calc_landing_page_with_landing_page(self):
+        page = "/asante"
+        startup = StartupFactory(landing_page=page)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup=startup)
+        profile = context.user.get_profile()
+        self.assertTrue(profile.calc_landing_page() == page)
+
+    def test_role_based_landing_page(self):
+        page = "/asante"
+        context = StartupTeamMemberContext(
+            primary_contact=False)
+        ur = UserRoleFactory(name=BaseUserRole.FINALIST)
+        pr = ProgramRoleFactory.create(
+            user_role=ur,
+            program=context.program,
+            landing_page=page)
+        ProgramRoleGrantFactory.create(person=context.user, program_role=pr)
+        profile = context.user.get_profile()
+        self.assertTrue(profile.role_based_landing_page() == page)
+
+    def test_role_based_landing_page_excluding_roles(self):
+        page = "/asante"
+        context = StartupTeamMemberContext(
+            primary_contact=False)
+        ur = UserRoleFactory(name=BaseUserRole.FINALIST)
+        pr = ProgramRoleFactory.create(
+            user_role=ur,
+            program=context.program,
+            landing_page=page)
+        ProgramRoleGrantFactory.create(person=context.user, program_role=pr)
+        profile = context.user.get_profile()
+        landing_page = profile.role_based_landing_page(exclude_role_names=[
+            BaseUserRole.FINALIST
+        ])
+        default_page = profile.default_page
+        self.assertTrue(landing_page == default_page)

--- a/accelerator/tests/test_startup.py
+++ b/accelerator/tests/test_startup.py
@@ -7,7 +7,15 @@ from django.test import TestCase
 
 from accelerator.tests.factories import (
     OrganizationFactory,
+    ProgramFactory,
     StartupFactory,
+    StartupRoleFactory
+)
+from accelerator_abstract.models.base_startup_role import (
+    BaseStartupRole
+)
+from accelerator.tests.contexts import (
+    StartupTeamMemberContext
 )
 
 
@@ -92,3 +100,18 @@ class TestStartup(TestCase):
     def test_startup_repr_returns_empty_string_when_org_is_empty(self):
         startup = StartupFactory(organization=None)
         self.assertEqual(startup.__str__(), "")
+
+    def test_is_finalist(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        self.assertTrue(context.startup.is_finalist())
+
+    def test_is_finalist_with_program_passed_in(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        self.assertFalse(
+            context.startup.is_finalist(ProgramFactory()))

--- a/accelerator/tests/test_user_role.py
+++ b/accelerator/tests/test_user_role.py
@@ -5,7 +5,17 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from accelerator.tests.factories import UserRoleFactory
+from accelerator.tests.factories import (
+    UserRoleFactory,
+    ProgramFactory
+)
+from accelerator_abstract.models.base_user_role import (
+    BaseUserRole,
+    is_finalist_user,
+    is_judge,
+    is_mentor,
+)
+from accelerator.tests.test_core_profile import expert
 
 
 class TestUserRole(TestCase):
@@ -13,3 +23,19 @@ class TestUserRole(TestCase):
     def test_str(self):
         user_role = UserRoleFactory()
         self.assertEqual(str(user_role), user_role.name)
+
+    def test_is_finalist(self):
+        user = expert(BaseUserRole.FINALIST)
+        self.assertTrue(is_finalist_user(user))
+
+    def test_is_mentor(self):
+        user = expert(BaseUserRole.MENTOR)
+        self.assertTrue(is_mentor(user))
+
+    def test_is_judge(self):
+        user = expert(BaseUserRole.JUDGE)
+        self.assertTrue(is_judge(user))
+
+    def test_has_user_role_with_program(self):
+        user = expert(BaseUserRole.FINALIST)
+        self.assertFalse(is_finalist_user(user, ProgramFactory()))

--- a/accelerator/tests/utils.py
+++ b/accelerator/tests/utils.py
@@ -17,7 +17,7 @@ TEST_PASSWORD = 'simplepass1'
 def login_as_user(test, user):
     user.set_password(TEST_PASSWORD)
     user.save()
-    return test.client.login(username=user.username, password=TEST_PASSWORD)
+    return test.client.login(username=user.email, password=TEST_PASSWORD)
 
 
 def login_as_new_user(test, factory, is_superuser=False):

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -162,12 +162,6 @@ class BaseCoreProfile(AcceleratorModel):
             return self.user.programrolegrant_set.filter(
                 program_role__user_role__name=BaseUserRole.MENTOR).exists()
 
-    @property
-    def mentor_profile_url(self):
-        if self.is_mentor():
-            return urlresolvers.reverse('mentor_view',
-                                        args=(self.user.id,))
-
     def user_roles(self):
         return set([prg.program_role.user_role
                     for prg in self.user.programrolegrant_set.all()

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -13,13 +13,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import urlresolvers
 from sorl.thumbnail import ImageField
 
-from accelerator_abstract.models.accelerator_model import AcceleratorModel
+from accelerator.apps import AcceleratorConfig
 
+from accelerator_abstract.models.accelerator_model import AcceleratorModel
 from accelerator_abstract.models.base_user_role import (
     BaseUserRole,
-)
-from accelerator_abstract.models.base_partner_team_member import (
-    BasePartnerTeamMember,
 )
 
 GENDER_MALE_CHOICE = ('m', 'Male')
@@ -181,11 +179,15 @@ class BaseCoreProfile(AcceleratorModel):
             BaseUserRole.OFFICE_HOUR_ROLES)) > 0
 
     def is_partner(self):
-        return BasePartnerTeamMember.objects.filter(
+        PartnerTeamMember = swapper.load_model(
+            AcceleratorConfig.name, 'PartnerTeamMember')
+        return PartnerTeamMember.objects.filter(
             team_member=self.user).exists()
 
     def is_partner_admin(self):
-        return BasePartnerTeamMember.objects.filter(
+        PartnerTeamMember = swapper.load_model(
+            AcceleratorConfig.name, 'PartnerTeamMember')
+        return PartnerTeamMember.objects.filter(
             team_member=self.user,
             partner_administrator=True).exists()
 

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -8,9 +8,6 @@ from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.models import ContentType
-from django.core import urlresolvers
 from sorl.thumbnail import ImageField
 
 from accelerator.apps import AcceleratorConfig
@@ -184,11 +181,6 @@ class BaseCoreProfile(AcceleratorModel):
         return PartnerTeamMember.objects.filter(
             team_member=self.user,
             partner_administrator=True).exists()
-
-    def get_admin_url(self):
-        content_type = ContentType.objects.get_for_model(get_user_model())
-        return urlresolvers.reverse("admin:%s_%s_change" % (
-            content_type.app_label, content_type.model), args=(self.user.id,))
 
     def get_active_alerts(self, page=None):
         """Return any active alerts for the user, that are relevant for

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -119,3 +119,10 @@ class BaseCoreProfile(AcceleratorModel):
 
     def full_name(self):
         return self.user.full_name()
+
+    def image_url(self):
+        if str(self.image):
+            return self.image.storage.url(
+                self.image.name)
+        else:
+            return ""

--- a/accelerator_abstract/models/base_permission_checks.py
+++ b/accelerator_abstract/models/base_permission_checks.py
@@ -22,10 +22,6 @@ def _see_employee_pages(user):
     return is_employee(user)
 
 
-def _see_staff_pages(user):
-    return _see_employee_pages(user) or user.is_superuser
-
-
 def _see_active_pages(user):
     profile = user.get_profile()
     return (_see_finalist_pages(user) or
@@ -35,6 +31,6 @@ def _see_active_pages(user):
 
 
 def _see_finalist_pages(user, inactive_programs=False):
-    return (_see_staff_pages(user) or
+    return (_see_employee_pages(user) or
             is_finalist_user(user, inactive_programs=inactive_programs) or
             finalist_startup_member(user))

--- a/accelerator_abstract/models/base_permission_checks.py
+++ b/accelerator_abstract/models/base_permission_checks.py
@@ -1,0 +1,40 @@
+from accelerator_abstract.models.base_user_utils import (
+    is_employee,
+)
+from accelerator_abstract.models.base_utils import (
+    finalist_startup_member
+)
+from accelerator_abstract.models.base_user_role import (
+    is_finalist_user
+)
+
+
+def base_accelerator_check(user):
+    return (
+        _see_active_pages(user) or
+        _see_finalist_pages(user, inactive_programs=True) or
+        user.get_profile().is_alum())
+
+
+def _see_employee_pages(user):
+    if user is None:
+        return False
+    return is_employee(user)
+
+
+def _see_staff_pages(user):
+    return _see_employee_pages(user) or user.is_superuser
+
+
+def _see_active_pages(user):
+    profile = user.get_profile()
+    return (_see_finalist_pages(user) or
+            profile.is_mentor() or
+            profile.is_office_hour_holder() or
+            profile.is_alum_in_residence())
+
+
+def _see_finalist_pages(user, inactive_programs=False):
+    return (_see_staff_pages(user) or
+            is_finalist_user(user, inactive_programs=inactive_programs) or
+            finalist_startup_member(user))

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -219,5 +219,5 @@ class BaseStartup(AcceleratorModel):
             startup_role__name=BaseStartupRole.FINALIST,
             program__exact=program
         ).exists()
-    
+
     is_finalist.boolean = True

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -219,3 +219,5 @@ class BaseStartup(AcceleratorModel):
             startup_role__name=BaseStartupRole.FINALIST,
             program__exact=program
         ).exists()
+    
+    is_finalist.boolean = True

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -208,6 +208,13 @@ class BaseStartup(AcceleratorModel):
             logger.warning(STARTUP_NO_ORG_WARNING_MSG.format(self.pk))
             return None
 
+    def program_startup_statuses(self):
+        from accelerator.models.program_startup_status import (
+            ProgramStartupStatus
+        )
+        return ProgramStartupStatus.objects.filter(
+            startupstatus__startup=self)
+
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist
         in that program. Otherwise, check whether this startup is a finalist

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -15,6 +15,7 @@ from embed_video.fields import EmbedVideoField
 from sorl.thumbnail import ImageField
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
+from accelerator_abstract.models.base_startup_role import BaseStartupRole
 
 logger = logging.getLogger(__name__)
 
@@ -206,3 +207,15 @@ class BaseStartup(AcceleratorModel):
         else:
             logger.warning(STARTUP_NO_ORG_WARNING_MSG.format(self.pk))
             return None
+
+    def is_finalist(self, program=None):
+        """if program is given, check whether this startup is a finalist
+        in that program. Otherwise, check whether this startup is a finalist
+        in any program"""
+        if program is None:
+            return self.program_startup_statuses().filter(
+                startup_role__name=BaseStartupRole.FINALIST).exists()
+        return self.program_startup_statuses().filter(
+            startup_role__name=BaseStartupRole.FINALIST,
+            program__exact=program
+        ).exists()

--- a/accelerator_abstract/models/base_user_role.py
+++ b/accelerator_abstract/models/base_user_role.py
@@ -47,3 +47,30 @@ class BaseUserRole(AcceleratorModel):
     class Meta(AcceleratorModel.Meta):
         abstract = True
         db_table = '{}_userrole'.format(AcceleratorModel.Meta.app_label)
+
+
+def has_user_role_base(
+        user, user_role_name, program=None, inactive_programs=False):
+    filter = user.programrolegrant_set.filter(
+        program_role__user_role__name=user_role_name)
+    if program:
+        filter = filter.filter(program_role__program=program)
+    if not inactive_programs:
+        filter = filter.filter(program_role__program__program_status__in=[
+            "active", "upcoming"])
+    return filter.exists()
+
+
+def is_finalist_user(user, program=None, inactive_programs=False):
+    return has_user_role_base(
+        user, BaseUserRole.FINALIST, program, inactive_programs)
+
+
+def is_mentor(user, program=None, inactive_programs=False):
+    return has_user_role_base(
+        user, BaseUserRole.MENTOR, program, inactive_programs)
+
+
+def is_judge(user, program=None, inactive_programs=False):
+    return has_user_role_base(
+        user, BaseUserRole.JUDGE, program, inactive_programs)

--- a/accelerator_abstract/models/base_utils.py
+++ b/accelerator_abstract/models/base_utils.py
@@ -1,0 +1,6 @@
+
+def finalist_startup_member(user):
+    for member in user.startupteammember_set.all():
+        if member.startup.is_finalist():
+            return True
+    return False

--- a/accelerator_abstract/tests/test_base_permissions_checks.py
+++ b/accelerator_abstract/tests/test_base_permissions_checks.py
@@ -1,0 +1,86 @@
+from django.test import TestCase
+
+from accelerator.tests.utils import login_as_new_user, login_as_user
+from accelerator_abstract.models.base_startup_role import (
+    BaseStartupRole
+)
+from accelerator_abstract.models.base_user_role import (
+    BaseUserRole
+)
+from accelerator.tests.contexts import (
+    StartupTeamMemberContext
+)
+from accelerator.tests.factories import (
+    StartupRoleFactory,
+    UserFactory
+)
+from accelerator_abstract.models.base_permission_checks import (
+    _see_active_pages,
+    _see_employee_pages,
+    _see_finalist_pages,
+    base_accelerator_check
+)
+from accelerator_abstract.models import ENDED_PROGRAM_STATUS
+from accelerator.tests.test_core_profile import expert
+
+
+class TestBasePermissionsChecks(TestCase):
+
+    def test_see_employee_pages_is_true_for_staff(self):
+        user = login_as_new_user(self, UserFactory, is_superuser=True)
+        self.assertTrue(_see_employee_pages(user))
+
+    def test_see_employee_pages_is_false_with_None_argument(self):
+        self.assertFalse(_see_employee_pages(None))
+
+    def test_staff_can_see_finalist_pages(self):
+        user = login_as_new_user(self, UserFactory, is_superuser=True)
+        self.assertTrue(_see_finalist_pages(user))
+
+    def test_finalist_startup_team_member_can_see_finalist_pages(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        login_as_user(self, context.user)
+        self.assertTrue(_see_finalist_pages(context.user))
+
+    def test_finalist_in_active_program_can_see_finalist_pages(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        login_as_user(self, context.user)
+        self.assertTrue(_see_finalist_pages(context.user))
+
+    def test_finalist_in_active_program_can_see_active_pages(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        login_as_user(self, context.user)
+        self.assertTrue(_see_active_pages(context.user))
+
+    def test_mentor_can_see_active_pages(self):
+        user = expert(BaseUserRole.MENTOR)
+        login_as_user(self, user)
+        self.assertTrue(_see_active_pages(user))
+
+    def test_office_hour_holder_can_see_active_pages(self):
+        user = expert(BaseUserRole.OFFICE_HOUR_HOLDER)
+        login_as_user(self, user)
+        self.assertTrue(_see_active_pages(user))
+
+    def test_alumni_in_residence_can_see_active_pages(self):
+        user = expert(BaseUserRole.AIR)
+        login_as_user(self, user)
+        self.assertTrue(_see_active_pages(user))
+
+    def test_finalist_in_inactive_program_passes_accelerator_check(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role,
+            program_status=ENDED_PROGRAM_STATUS)
+        login_as_user(self, context.user)
+        self.assertTrue(base_accelerator_check(context.user))

--- a/accelerator_abstract/tests/test_base_user_utils.py
+++ b/accelerator_abstract/tests/test_base_user_utils.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+from accelerator_abstract.models.base_user_utils import (
+    is_employee
+)
+from accelerator.tests.utils import login_as_new_user
+from accelerator.tests.factories import (
+    UserFactory,
+    ProgramRoleGrantFactory,
+    ProgramRoleFactory,
+    UserRoleFactory
+)
+from accelerator_abstract.models.base_user_role import (
+    BaseUserRole
+)
+
+
+class TestBaseUserUtils(TestCase):
+
+    def test_is_employee_for_anonymous_user_is_false(self):
+        self.assertFalse(is_employee(AnonymousUser()))
+
+    def test_is_employee_for_superuser_is_true(self):
+        user = login_as_new_user(self, UserFactory, is_superuser=True)
+        self.assertTrue(is_employee(user))
+
+    def test_is_employee_for_staff_is_true(self):
+        user = login_as_new_user(self, UserFactory)
+        ProgramRoleGrantFactory(
+            person=user,
+            program_role=ProgramRoleFactory(
+                user_role=UserRoleFactory(name=BaseUserRole.STAFF)))
+        self.assertTrue(is_employee(user))

--- a/accelerator_abstract/tests/test_base_utils.py
+++ b/accelerator_abstract/tests/test_base_utils.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from accelerator_abstract.models.base_utils import (
+    finalist_startup_member
+)
+from accelerator_abstract.models.base_startup_role import (
+    BaseStartupRole
+)
+from accelerator.tests.contexts import (
+    StartupTeamMemberContext
+)
+from accelerator.tests.factories import StartupRoleFactory
+
+
+class TestBaseUtils(TestCase):
+
+    def test_finalist_startup_is_true_for_startup_finalist(self):
+        startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
+        context = StartupTeamMemberContext(
+            primary_contact=False,
+            startup_role=startup_role)
+        self.assertTrue(finalist_startup_member(context.user))
+
+    def test_finalist_startup_is_true_for_startup_non_finalist(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        self.assertFalse(finalist_startup_member(context.user))

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -133,9 +133,9 @@ class User(AbstractUser):
 
     def finalist_user_roles(self):
         if not self.user_finalist_roles:
-            startup_roles = BaseUserRole.FINALIST_USER_ROLES
+            finalist_roles = BaseUserRole.FINALIST_USER_ROLES
             roles = self.programrolegrant_set.filter(
-                program_role__user_role__name__in=startup_roles
+                program_role__user_role__name__in=finalist_roles
             ).values_list('program_role__name', flat=True).distinct()
             self.user_finalist_roles = [role for role in roles]
         return self.user_finalist_roles

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -134,11 +134,10 @@ class User(AbstractUser):
     def finalist_user_roles(self):
         if not self.user_finalist_roles:
             finalist_roles = BaseUserRole.FINALIST_USER_ROLES
-            roles = self.programrolegrant_set.filter(
+            self.user_finalist_roles = self.programrolegrant_set.filter(
                 program_role__user_role__name__in=finalist_roles
             ).values_list('program_role__name', flat=True).distinct()
-            self.user_finalist_roles = [role for role in roles]
-        return self.user_finalist_roles
+        return list(self.user_finalist_roles)
 
     def program(self):
         return self.startup.current_program() if self._get_startup() else None

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -88,7 +88,7 @@ class User(AbstractUser):
             name = str(self.email)
         return name
 
-    def phone(self):
+    def user_phone(self):
         return self._get_profile().phone
 
     def image_url(self):
@@ -97,22 +97,22 @@ class User(AbstractUser):
     def team_member_id(self):
         return self.team_member.id if self._get_member() else ''
 
-    def title(self):
+    def user_title(self):
         return self.team_member.title if self._get_member() else ''
 
-    def twitter_handle(self):
+    def user_twitter_handle(self):
         return self._get_profile().twitter_handle
 
-    def linked_in_url(self):
+    def user_linked_in_url(self):
         return self._get_profile().linked_in_url
 
-    def facebook_url(self):
+    def user_facebook_url(self):
         return self._get_profile().facebook_url
 
-    def personal_website_url(self):
+    def user_personal_website_url(self):
         return self._get_profile().personal_website_url
 
-    def user_type(self):
+    def type(self):
         return self._get_profile().user_type
 
     def startup_name(self):

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -10,6 +10,9 @@ from django.contrib.auth.models import BaseUserManager
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
+from accelerator_abstract.models import BaseUserRole
+
+
 MAX_USERNAME_LENGTH = 30
 
 
@@ -63,6 +66,12 @@ class User(AbstractUser):
         db_table = 'auth_user'
         managed = settings.ACCELERATOR_MODELS_ARE_MANAGED
 
+    def __init__(self, *args, **kwargs):
+        super(User, self).__init__(*args, **kwargs)
+        self.startup = None
+        self.team_member = None
+        self.profile = None
+
     class AuthenticationException(Exception):
         pass
 
@@ -77,3 +86,85 @@ class User(AbstractUser):
         else:
             name = str(self.email)
         return name
+
+    def phone(self):
+        return self._get_profile().phone
+
+    def image_url(self):
+        return self._get_profile().image_url()
+
+    def team_member_id(self):
+        return self.team_member.id if self._get_member() else ''
+
+    def title(self):
+        return self.team_member.title if self._get_member() else ''
+
+    def twitter_handle(self):
+        return self._get_profile().twitter_handle
+
+    def linked_in_url(self):
+        return self._get_profile().linked_in_url
+
+    def facebook_url(self):
+        return self._get_profile().facebook_url
+
+    def personal_website_url(self):
+        return self._get_profile().personal_website_url
+
+    def user_type(self):
+        return self._get_profile().user_type
+
+    def startup_name(self):
+        return self.startup.name if self._get_startup() else None
+
+    def startup_industry(self):
+        return self.startup.primary_industry if self._get_startup() else None
+
+    def top_level_startup_industry(self):
+        industry = (
+            self.startup.primary_industry if self._get_startup() else None)
+        return industry.parent if industry and industry.parent else industry
+
+    def startup_status_names(self):
+        if self._get_startup():
+            return [startup_status.program_startup_status.startup_status
+                    for startup_status in self.startup.startupstatus_set.all()]
+
+    def finalist_user_roles(self):
+        startup_roles = BaseUserRole.FINALIST_USER_ROLES
+        roles = self.programrolegrant_set.filter(
+            program_role__user_role__name__in=startup_roles
+        ).values_list('program_role__name', flat=True).distinct()
+        return [role for role in roles]
+
+    def program(self):
+        return self.startup.current_program() if self._get_startup() else None
+
+    def location(self):
+        program = self.program()
+        return program.program_family.name if program else None
+
+    def year(self):
+        program = self.program()
+        return program.start_date.year if program else None
+
+    def is_team_member(self):
+        return True if self._get_member() else False
+
+    def _get_startup(self):
+        if not self.startup:
+            self._get_member()
+            if self.team_member:
+                self.startup = self.team_member.startup
+        return self.startup
+
+    def _get_member(self):
+        if not self.team_member:
+            self.team_member = self.startupteammember_set.last()
+        return self.team_member
+
+    def _get_profile(self):
+        if self.profile:
+            return self.profile
+        self.profile = self.get_profile()
+        return self.profile

--- a/simpleuser/tests/test_models.py
+++ b/simpleuser/tests/test_models.py
@@ -34,12 +34,12 @@ class TestUser(TestCase):
     def test_that_correct_entrepreneur_user_type_is_returned(self):
         user = EntrepreneurFactory()
         user = User.objects.get(pk=user.pk)
-        self.assertEqual('entrepreneur', user.user_type())
+        self.assertEqual('entrepreneur', user.type())
 
     def test_that_correct_expert_user_type_is_returned(self):
         user = ExpertFactory()
         user = User.objects.get(pk=user.pk)
-        self.assertEqual('expert', user.user_type())
+        self.assertEqual('expert', user.type())
 
     def test_startup_name_is_correct(self):
         context = StartupTeamMemberContext(primary_contact=False)
@@ -98,14 +98,14 @@ class TestUser(TestCase):
             profile__personal_website_url='http://example.com/0'
         )
         user = User.objects.get(pk=user.pk)
-        self.assertEqual('111', user.phone())
-        self.assertEqual('tw0', user.twitter_handle())
+        self.assertEqual('111', user.user_phone())
+        self.assertEqual('tw0', user.user_twitter_handle())
         self.assertEqual('http://www.linkedin.com/0',
-                         user.linked_in_url())
+                         user.user_linked_in_url())
         self.assertEqual('http://www.facebook.com/0',
-                         user.facebook_url())
+                         user.user_facebook_url())
         self.assertEqual('http://example.com/0',
-                         user.personal_website_url())
+                         user.user_personal_website_url())
 
     def test_startup_status_names(self):
         status = ProgramStartupStatusFactory()
@@ -135,11 +135,11 @@ class TestUser(TestCase):
     def test_team_member_title(self):
         context = StartupTeamMemberContext(primary_contact=False)
         self.assertTrue(
-            context.user.title() == context.member.title)
+            context.user.user_title() == context.member.title)
 
     def test_non_team_member_title(self):
         user = UserFactory()
-        self.assertTrue(user.title() == '')
+        self.assertTrue(user.user_title() == '')
 
     def test_missing_profile_image_url_returns_empty(self):
         context = StartupTeamMemberContext(primary_contact=False)

--- a/simpleuser/tests/test_models.py
+++ b/simpleuser/tests/test_models.py
@@ -1,11 +1,189 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
+from django.utils.six import StringIO
+
+from datetime import datetime
 from django.test import TestCase
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from .factories.user_factory import UserFactory
+from mock import MagicMock
+from accelerator.tests.factories import (
+    EntrepreneurFactory,
+    ExpertFactory,
+    IndustryFactory,
+    ProgramFactory,
+    StartupFactory,
+    StartupStatusFactory,
+    ProgramStartupStatusFactory,
+    ProgramRoleGrantFactory,
+    ProgramRoleFactory,
+    UserRoleFactory,
+)
+from accelerator.tests.contexts import (
+    StartupTeamMemberContext
+)
+from simpleuser.models import User
 
 
 class TestUser(TestCase):
     def test_str(self):
         user = UserFactory()
         assert user.email in str(user)
+
+    def test_that_correct_entrepreneur_user_type_is_returned(self):
+        user = EntrepreneurFactory()
+        user = User.objects.get(pk=user.pk)
+        self.assertEqual('entrepreneur', user.user_type())
+
+    def test_that_correct_expert_user_type_is_returned(self):
+        user = ExpertFactory()
+        user = User.objects.get(pk=user.pk)
+        self.assertEqual('expert', user.user_type())
+
+    def test_startup_name_is_correct(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        startup = context.startup
+        user = context.user
+        self.assertEqual(startup.name, user.startup_name())
+
+    def test_startup_industry_is_correct(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        startup = context.startup
+        user = context.user
+        self.assertEqual(startup.primary_industry,
+                         user.startup_industry())
+
+    def test_startup_top_level_industry_is_correct(self):
+        industry = IndustryFactory(parent=IndustryFactory())
+        startup = StartupFactory(primary_industry=industry)
+        context = StartupTeamMemberContext(
+            primary_contact=False, startup=startup)
+        user = context.user
+        self.assertEqual(industry.parent,
+                         user.top_level_startup_industry())
+
+    def test_location(self):
+        program = ProgramFactory()
+        user = User()
+        user.program = MagicMock(return_value=program)
+        self.assertEqual(program.program_family.name, user.location())
+
+    def test_year(self):
+        datetime_object = datetime.strptime('Jun 1 2005', '%b %d %Y')
+        program = ProgramFactory(start_date=datetime_object)
+        user = User()
+        user.program = MagicMock(return_value=program)
+        self.assertEqual(2005, user.year())
+
+    def test_current_program(self):
+        startup = StartupFactory()
+        startup.current_program = MagicMock()
+        user = User()
+        user.startup = startup
+        user.program()
+        startup.current_program.assert_any_call()
+
+    def test_expert_startup_name_is_none(self):
+        user = ExpertFactory()
+        user = User.objects.get(pk=user.pk)
+        self.assertEqual(user.startup_name(), None)
+
+    def test_basic_getters_return_expected_results(self):
+        user = ExpertFactory(
+            profile__phone="111",
+            profile__twitter_handle='tw0',
+            profile__linked_in_url='http://www.linkedin.com/0',
+            profile__facebook_url='http://www.facebook.com/0',
+            profile__personal_website_url='http://example.com/0'
+        )
+        user = User.objects.get(pk=user.pk)
+        self.assertEqual('111', user.phone())
+        self.assertEqual('tw0', user.twitter_handle())
+        self.assertEqual('http://www.linkedin.com/0',
+                         user.linked_in_url())
+        self.assertEqual('http://www.facebook.com/0',
+                         user.facebook_url())
+        self.assertEqual('http://example.com/0',
+                         user.personal_website_url())
+
+    def test_startup_status_names(self):
+        status = ProgramStartupStatusFactory()
+        context = StartupTeamMemberContext(primary_contact=False)
+        StartupStatusFactory(startup=context.startup,
+                             program_startup_status=status)
+        status_names = context.user.startup_status_names()
+        self.assertTrue(status.startup_status in status_names)
+
+    def test_is_team_member_flag_on_user_with_startup(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        self.assertTrue(context.user.is_team_member())
+
+    def test_is_team_member_flag_on_user_without_startup(self):
+        user = UserFactory()
+        self.assertFalse(user.is_team_member())
+
+    def test_team_member_id_of_team_member(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        self.assertTrue(
+            context.user.team_member_id() == context.member.id)
+
+    def test_team_member_id_of_non_team_member(self):
+        user = UserFactory()
+        self.assertTrue(user.team_member_id() == '')
+
+    def test_team_member_title(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        self.assertTrue(
+            context.user.title() == context.member.title)
+
+    def test_non_team_member_title(self):
+        user = UserFactory()
+        self.assertTrue(user.title() == '')
+
+    def test_missing_profile_image_url_returns_empty(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        image_url = context.user.get_profile().image_url()
+        self.assertTrue(context.user.image_url() == image_url)
+
+    def test_s3_profile_image_url(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        user = context.user
+        profile = user.get_profile()
+        image = InMemoryUploadedFile(
+            StringIO("test image data"),
+            field_name='tempfile',
+            name='tempfile.png',
+            content_type='image/png',
+            size=len("test image data"),
+            charset='utf-8',
+        )
+        profile.image = image
+        profile.save()
+        media_root = 'media'
+        bucket_name = 'test-bucket'
+        custom_domain_url = "{}.s3.amazonaws.com".format(bucket_name)
+        with self.settings(**{
+            'AWS_LOCATION': media_root,
+            'AWS_ACCESS_KEY_ID': 'mock_access_key',
+            'AWS_SECRET_ACCESS_KEY': 'mock_key',
+            'AWS_STORAGE_BUCKET_NAME': bucket_name,
+            'AWS_S3_CUSTOM_DOMAIN': custom_domain_url,
+            'AWS_S3_OBJECT_PARAMETERS': {'CacheControl': 'max-age=86400'},
+            'MEDIA_URL': 'https://{}/{}/'.format(
+                custom_domain_url, media_root),
+            'MEDIA_ROOT': media_root
+        }):
+            image_url = profile.image_url()
+            self.assertTrue(
+                image_url.startswith("https://{}/".format(custom_domain_url)))
+
+    def test_finalist_user_roles(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        role_grant = ProgramRoleGrantFactory(
+            person=context.user,
+            program_role=ProgramRoleFactory(
+                user_role=UserRoleFactory(name='Staff'))
+        )
+        finalist_roles = context.user.finalist_user_roles()
+        self.assertTrue(role_grant.program_role.name in finalist_roles)

--- a/simpleuser/tests/test_models.py
+++ b/simpleuser/tests/test_models.py
@@ -187,3 +187,12 @@ class TestUser(TestCase):
         )
         finalist_roles = context.user.finalist_user_roles()
         self.assertTrue(role_grant.program_role.name in finalist_roles)
+
+    def test_has_a_finalist_role(self):
+        context = StartupTeamMemberContext(primary_contact=False)
+        ProgramRoleGrantFactory(
+            person=context.user,
+            program_role=ProgramRoleFactory(
+                user_role=UserRoleFactory(name='Staff'))
+        )
+        self.assertTrue(context.user.has_a_finalist_role())


### PR DESCRIPTION
#### Changes introduced in [AC-6377](https://masschallenge.atlassian.net/browse/AC-6377)
- move logic from accelerate into here to allow algolia to reindex automatically when a User object is saved

#### How to test
this is deployed on test2
- visit test2 and log in as staff
- now visit https://test2.masschallenge.org/people/ and behold the new people directory

if local testing is your thing
- checkout this branch on the directory and impact
- ensure to be logged in on accelerate
- visit localhost:1234/people and behold the new people directory

#### Note
- there are 3 related PRs ([accelerate](https://github.com/masschallenge/accelerate/pull/2117), [directory](https://github.com/masschallenge/directory/pull/136), [impact](https://github.com/masschallenge/impact-api/pull/275)). The accelerator PR should be merged in first, then the order of the merge is not important but it's important that a deploy is not done when changes have not been completely merged across all repos.

#### Other Note
These two commits ([8324b21](https://github.com/masschallenge/django-accelerator/pull/163/commits/8324b21b76d45dff04f8e6e221e365292d30b32d), [cef020b](https://github.com/masschallenge/django-accelerator/pull/163/commits/cef020bd4fe91ac0b6cd460ca0f50bfe1789e52d)) are as a result of impact needing accelerate logic used to identify who can access the people directory. Moving these utility functions cascaded down to the CoreProfileMixin whose logic was moved to the BaseCoreProfile here, qns about "whys" are welcome.