### PR TITLE
AC-5610: Add issue-number in commit message git-hook to django-accelerator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ $(VENV): requirements/base.txt requirements/dev.txt Makefile
 	@pip install virtualenv
 	@rm -rf $(VENV)
 	@virtualenv -p `which $(PYTHON_VERSION)` $@
+	@cp git-hooks/* .git/hooks/
 	@touch $(ACTIVATE_SCRIPT)
 	@$(ACTIVATE) ; \
 	DJANGO_VERSION=$(DJANGO_VERSION) pip install -r requirements/dev.txt

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -24,6 +24,6 @@ exec 1>&2
 DEBUG_FUNC=set_trace
 if git diff $against | grep -v '^-' | grep "$DEBUG_FUNC"
 then
-    echo "Commit failed. 'import $DEBUG_LIB' detected."
+    echo "Commit failed. 'pdb $DEBUG_FUNC' detected."
     exit 1
 fi

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+# allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+DEBUG_FUNC=set_trace
+if git diff $against | grep -v '^-' | grep "$DEBUG_FUNC"
+then
+    echo "Commit failed. 'import $DEBUG_LIB' detected."
+    exit 1
+fi

--- a/git-hooks/prepare-commit-msg
+++ b/git-hooks/prepare-commit-msg
@@ -1,0 +1,17 @@
+#!/bin/bash
+ 
+# This way you can customize which branches should be skipped when
+# prepending commit message. 
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(master development test)
+fi
+ 
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+BRANCH_NAME="${BRANCH_NAME##*/}"
+ 
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
+ 
+if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
+  sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
+fi


### PR DESCRIPTION
#### Changes introduced in [AC-5610](https://masschallenge.atlassian.net/browse/AC-5610)
- add precommit git hooks

#### How to test
- checkout this branch
- run `make clean`. to delete the venv
- run `make code-check`. this simulates a situation where django-accelerator will rebuild it's virtualenv and in the process set up the git hook
- once this is done, add `import pdb; pdb.set_trace()` in a file and stage the file i.e. `git add <file-you-added-pdb-to>` and attempt to commit the file. Note that the commit is blocked as it would be on impact/ accelerate.
- Now make a random, legal change and commit it. Note that the branch name is appended to the commit message like it is on accelerate/ impact
