### PR TITLE
AC-6373: Migration 0009_create_initial_criteria should not fail on an empty database

### DIFF
--- a/accelerator/migrations/0009_create_initial_criteria.py
+++ b/accelerator/migrations/0009_create_initial_criteria.py
@@ -33,9 +33,9 @@ def handle_spec(spec, apps):
 
     data = CriterionData(*spec)
     name = data.name
-    jr_exists = JudgingRound.objects.filter(
+    judging_round_exists = JudgingRound.objects.filter(
         id=BOS_2017_JUDGING_ROUND_ID).exists()
-    if name not in criteria and jr_exists:
+    if name not in criteria and judging_round_exists:
         criteria[name] = Criterion.objects.create(
             name=name,
             type=data.type,

--- a/accelerator/migrations/0009_create_initial_criteria.py
+++ b/accelerator/migrations/0009_create_initial_criteria.py
@@ -29,20 +29,25 @@ def create_initial_criteria(apps, schema_editor):
 def handle_spec(spec, apps):
     Criterion = apps.get_model('accelerator', 'Criterion')
     CriterionOptionSpec = apps.get_model('accelerator', 'CriterionOptionSpec')
+    JudgingRound = apps.get_model('accelerator', 'JudgingRound')
 
     data = CriterionData(*spec)
     name = data.name
-    if name not in criteria:
+    jr_exists = JudgingRound.objects.filter(
+        id=BOS_2017_JUDGING_ROUND_ID).exists()
+    if name not in criteria and jr_exists:
         criteria[name] = Criterion.objects.create(
             name=name,
             type=data.type,
             judging_round_id=BOS_2017_JUDGING_ROUND_ID)
 
-    criterion = criteria[name]
-    CriterionOptionSpec.objects.create(criterion=criterion,
-                                       option=data.option,
-                                       weight=float(data.weight),
-                                       count=int(data.count))
+    criterion = criteria.get(name)
+    if criterion:
+        CriterionOptionSpec.objects.create(
+            criterion=criterion,
+            option=data.option,
+            weight=float(data.weight),
+            count=int(data.count))
 
 
 def destroy_all_criteria(apps, schema_editor):


### PR DESCRIPTION
#### Changes introduced in [AC-6373](https://masschallenge.atlassian.net/browse/AC-6373)
- ensure migration 009 does not attempt to create criteria for a judging round that does not exist

#### How to test
- be on development in django-accelerator
- on impact, run `make db-shell` and while there run `create database mc_dev_1;`
- in the `.dev.env` change `mc_dev` to `mc_dev_1` on L5
- then run `make migrate`, note the migration failure
- now checkout AC-6373 on django-accelerator
- and run `make migrate` again, note that the migrations now run to completion with no error

#### Why this change
When creating stacks on AWS, migrations initially run on an empty database and a failing migration stops the impact server from being accessible. This allows the whole stack be accessible when it's initially created

#### Undo testing state
Make sure your `.dev.env` file is reverted back to it's original state to avoid bugs.
