### PR TITLE
AC-6622: AC-6622: Internal Server Error on /startup/000/team/add and /accounts/register/entrepreneur/

### DIFF
--- a/accelerator/managers/member_profile_manager.py
+++ b/accelerator/managers/member_profile_manager.py
@@ -1,10 +1,19 @@
+import logging
+
 from django.db import models
+
+
+logger = logging.getLogger(__file__)
+MEMBER_PROFILE_RECREATION_WARNING = (
+    "Request made for MemberProfile creation "
+    "for user, {user}, already with profile. Recreating new MemberProfile."
+)
 
 
 class MemberProfileManager(models.Manager):
 
     def create(self, *args, **kwargs):
-        profile = self.filter(user=kwargs['user']).first()
-        if profile:
-            profile.delete()
+        self.filter(user=kwargs['user']).delete()
+        logger.warning(MEMBER_PROFILE_RECREATION_WARNING.format(
+            user=kwargs['user']))
         return super(MemberProfileManager, self).create(*args, **kwargs)

--- a/accelerator/managers/member_profile_manager.py
+++ b/accelerator/managers/member_profile_manager.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class MemberProfileManager(models.Manager):
+
+    def create(self, *args, **kwargs):
+        profile = self.filter(user=kwargs['user']).first()
+        if profile:
+            profile.delete()
+        return super(MemberProfileManager, self).create(*args, **kwargs)

--- a/accelerator/managers/profile_manager.py
+++ b/accelerator/managers/profile_manager.py
@@ -1,7 +1,17 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
+import logging
+
 from django.db import models
+
+
+logger = logging.getLogger(__file__)
+PROFILE_CREATION_WARNING = (
+    "Request made for {profile_type}Profile creation "
+    "for user, {user}, already with MemberProfile. "
+    "Deleted existing MemberProfile and creating new {profile_type}Profile."
+)
 
 
 class ProfileManager(models.Manager):
@@ -17,7 +27,8 @@ class ProfileManager(models.Manager):
         return ProfileQuerySet(self.model, using=self._db)
 
     def create(self, *args, **kwargs):
-        profile = self.filter(user=kwargs['user']).first()
-        if profile:
-            profile.delete()
+        self.filter(user=kwargs['user'], user_type="MEMBER").delete()
+        logger.warning(PROFILE_CREATION_WARNING.format(
+            profile_type=kwargs['user_type'].title(),
+            user=kwargs['user']))
         return super(ProfileManager, self).create(*args, **kwargs)

--- a/accelerator/managers/profile_manager.py
+++ b/accelerator/managers/profile_manager.py
@@ -15,3 +15,9 @@ class ProfileManager(models.Manager):
             ProfileQuerySet
         )
         return ProfileQuerySet(self.model, using=self._db)
+
+    def create(self, *args, **kwargs):
+        profile = self.filter(user=kwargs['user']).first()
+        if profile:
+            profile.delete()
+        return super(ProfileManager, self).create(*args, **kwargs)

--- a/accelerator/tests/factories/base_profile_factory.py
+++ b/accelerator/tests/factories/base_profile_factory.py
@@ -21,3 +21,11 @@ class BaseProfileFactory(DjangoModelFactory):
 
     user = SubFactory(UserFactory)
     user_type = "ENTREPRENEUR"
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        profile = model_class.objects.filter(user=kwargs['user'])
+        if profile:
+            profile.delete()
+        manager = cls._get_manager(model_class)
+        return manager.create(*args, **kwargs)

--- a/accelerator/tests/factories/base_profile_factory.py
+++ b/accelerator/tests/factories/base_profile_factory.py
@@ -24,8 +24,7 @@ class BaseProfileFactory(DjangoModelFactory):
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
-        profile = model_class.objects.filter(user=kwargs['user'])
-        if profile:
-            profile.delete()
+        model_class.objects.filter(
+            user=kwargs['user'], user_type="MEMBER").delete()
         manager = cls._get_manager(model_class)
         return manager.create(*args, **kwargs)

--- a/accelerator/tests/factories/member_profile_factory.py
+++ b/accelerator/tests/factories/member_profile_factory.py
@@ -14,11 +14,3 @@ MemberProfile = swapper.load_model(AcceleratorConfig.name, 'MemberProfile')
 class MemberProfileFactory(CoreProfileFactory):
     class Meta:
         model = MemberProfile
-
-    @classmethod
-    def _create(cls, model_class, *args, **kwargs):
-        profile = model_class.objects.filter(user=kwargs['user'])
-        if profile:
-            profile.delete()
-        manager = cls._get_manager(model_class)
-        return manager.create(*args, **kwargs)

--- a/accelerator/tests/factories/member_profile_factory.py
+++ b/accelerator/tests/factories/member_profile_factory.py
@@ -14,3 +14,11 @@ MemberProfile = swapper.load_model(AcceleratorConfig.name, 'MemberProfile')
 class MemberProfileFactory(CoreProfileFactory):
     class Meta:
         model = MemberProfile
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        profile = model_class.objects.filter(user=kwargs['user'])
+        if profile:
+            profile.delete()
+        manager = cls._get_manager(model_class)
+        return manager.create(*args, **kwargs)


### PR DESCRIPTION
#### Changes introduced in [AC-6622](https://masschallenge.atlassian.net/browse/AC-6622)
- override create method on objects manager to delete existing profile before creating another

#### How to test
On local
- on accelerate open the `mcproject/settings.py` file and fill in the fields below
```
ALGOLIA = {
    'APPLICATION_ID': '', # get this from your impact-api .env file i.e. ALGOLIA_APPLICATION_ID
    'API_KEY': '', # get this from your impact-api .env file i.e. ALGOLIA_API_KEY
    'INDEX_PREFIX': 'dev'
}

ALGOLIA_ENABLED = True
```
- while on development on all branches
- go to http://localhost:8181/accounts/register/entrepreneur/ and create an entrepreneur, see the failure with a duplicate user error
- checkout AC-6622 on accelerate and accelerator
- go to http://localhost:8181/accounts/register/entrepreneur/ and create an entrepreneur, see that it works

This is also deployed on test2 for further QA testing.

#### Note
Ensure to merge this before the [sibling PR](https://github.com/masschallenge/accelerate/pull/2141)