### PR TITLE
AC-6662: 500 error received when attempting to delete a user

### DIFF
--- a/accelerator/models/profile_query_set.py
+++ b/accelerator/models/profile_query_set.py
@@ -74,7 +74,8 @@ class ProfileQuerySet(QuerySet):
     def _profile_for_inferred_profile_type(self, profile_manager):
         if profile_manager is None:
             return None
-        profile = profile_manager.using(self._db).filter(user=self.user).first()
+        profile_qs = profile_manager.using(self._db).filter(user=self.user)
+        profile = profile_qs.first()
         if not profile:
             profile = self._get_profile_from_existing_profile_types()
         return profile

--- a/accelerator/tests/test_get_profile.py
+++ b/accelerator/tests/test_get_profile.py
@@ -22,14 +22,12 @@ from accelerator.models import (
 )
 from accelerator.models.profile_query_set import (
     INCORRECT_USER_TYPE_TEMPLATE,
-    MISSING_PROFILE_TEMPLATE,
 )
 from accelerator.tests.factories import (
     EntrepreneurFactory,
     ExpertFactory,
     MemberFactory,
 )
-from simpleuser.tests.factories import UserFactory
 
 User = get_user_model()
 
@@ -93,4 +91,3 @@ class TestGetProfile(TestCase):
         mock_logger.warning.assert_called_with(
             INCORRECT_USER_TYPE_TEMPLATE.format(ENTREPRENEUR_USER_TYPE,
                                                 EXPERT_USER_TYPE))
-

--- a/accelerator/tests/test_get_profile.py
+++ b/accelerator/tests/test_get_profile.py
@@ -22,7 +22,6 @@ from accelerator.models import (
 )
 from accelerator.models.profile_query_set import (
     INCORRECT_USER_TYPE_TEMPLATE,
-    MISSING_BASE_PROFILE_TEMPLATE,
     MISSING_PROFILE_TEMPLATE,
 )
 from accelerator.tests.factories import (
@@ -95,17 +94,3 @@ class TestGetProfile(TestCase):
             INCORRECT_USER_TYPE_TEMPLATE.format(ENTREPRENEUR_USER_TYPE,
                                                 EXPERT_USER_TYPE))
 
-    @patch("accelerator.models.profile_query_set.logger")
-    def test_get_profile_handles_a_user_without_a_profile(self, mock_logger):
-        entrepreneur = UserFactory()
-        profile = BaseProfile.manager.filter(user=entrepreneur).first()
-        assert profile is None
-        profile = entrepreneur.get_profile()
-
-        self.assertIsInstance(profile, MemberProfile)
-        entrepreneur.refresh_from_db()
-        self.assertEqual(entrepreneur.baseprofile.user_type, MEMBER_USER_TYPE)
-        mock_logger.warning.assert_called_with(
-            MISSING_PROFILE_TEMPLATE.format(MEMBER_USER_TYPE))
-        mock_logger.warning.assert_any_call(
-            MISSING_BASE_PROFILE_TEMPLATE.format(entrepreneur))

--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,12 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 import os
+import sys
+import logging
+
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.CRITICAL)
+
 
 PACKAGE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                             "accelerator"))

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -94,6 +94,9 @@ class User(AbstractUser):
             name = str(self.email)
         return name
 
+    def has_profile(self):
+        return self._get_profile() is not None
+
     def user_phone(self):
         return self._get_profile().phone
 

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 import uuid
+import swapper
 
 from django.db import models
 from django.conf import settings
@@ -11,6 +12,8 @@ from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models import BaseUserRole
+
+from accelerator.apps import AcceleratorConfig
 
 
 MAX_USERNAME_LENGTH = 30
@@ -44,6 +47,9 @@ class UserManager(BaseUserManager):
                           last_login=now, date_joined=now, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
+
+        BaseProfile = swapper.load_model(AcceleratorConfig.name, 'BaseProfile')
+        BaseProfile.objects.create(user=user, user_type='MEMBER')
         return user
 
     def create_user(self, email=None, password=None, **extra_fields):


### PR DESCRIPTION
#### Changes introduced in [AC-6662](https://masschallenge.atlassian.net/browse/AC-6662)
- stop logic from auto creating profiles on query set `get`, instead do that on user creation

#### How to test
- with a clean db
- while on development on both accelerate and django-accelerator
- log in as demoadmin
- try and delete [30-user](http://localhost:8181/admin/simpleuser/user/30/delete/) and [38298-user](http://localhost:8181/admin/simpleuser/user/38298/delete/), notice that both of these fail.
    - 38298-user has PartnerTeamMembers associated
    - 30-user has both PartnerTeamMembers and StartupStatus associated
- now checkout AC-6662 on both accelerate and django-accelerator
- try and delete [30-user](http://localhost:8181/admin/simpleuser/user/30/delete/) and [38298-user](http://localhost:8181/admin/simpleuser/user/38298/delete/) again, notice that it now passes. Success🏆 

#### Note
This PR has a sibling on [accelerate](https://github.com/masschallenge/accelerate/pull/2154) and this should be merged in first