### PR TITLE
AC-6715: Silence logging when running tests on impact-api

### DIFF
--- a/accelerator/managers/member_profile_manager.py
+++ b/accelerator/managers/member_profile_manager.py
@@ -14,6 +14,6 @@ class MemberProfileManager(models.Manager):
 
     def create(self, *args, **kwargs):
         self.filter(user=kwargs['user']).delete()
-        logger.warning(MEMBER_PROFILE_RECREATION_WARNING.format(
+        logger.info(MEMBER_PROFILE_RECREATION_WARNING.format(
             user=kwargs['user']))
         return super(MemberProfileManager, self).create(*args, **kwargs)

--- a/accelerator/managers/profile_manager.py
+++ b/accelerator/managers/profile_manager.py
@@ -28,7 +28,7 @@ class ProfileManager(models.Manager):
 
     def create(self, *args, **kwargs):
         self.filter(user=kwargs['user'], user_type="MEMBER").delete()
-        logger.warning(PROFILE_CREATION_WARNING.format(
+        logger.info(PROFILE_CREATION_WARNING.format(
             profile_type=kwargs['user_type'].title(),
             user=kwargs['user']))
         return super(ProfileManager, self).create(*args, **kwargs)

--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,11 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 import os
+import sys
+import logging
+
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.INFO)
 
 PACKAGE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                             "accelerator"))


### PR DESCRIPTION
#### Changes introduced in AC-6715
- make verbose logs info level rather than warning
- disable info logging

#### How to test
- while on development
- run `make test` in django-accelerator and notice the logging that drowns out basically everything
- now checkout AC-6715
- run `make test` again and see our tests are back to cleanliness 🏆