### PR TITLE
Rename eventbrite_organization_id field to eventbrite_organizer_id

### DIFF
--- a/accelerator/migrations/0054_add_eventbrite_organizer_id_field.py
+++ b/accelerator/migrations/0054_add_eventbrite_organizer_id_field.py
@@ -11,9 +11,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameField(
+        migrations.AddField(
             model_name='program',
-            old_name='eventbrite_organization_id',
-            new_name='eventbrite_organizer_id'
+            name='eventbrite_organizer_id',
+            field=models.CharField(blank=True, max_length=20, null=True),
         )
     ]

--- a/accelerator/migrations/0054_update_eventbrite_organizer_id_field.py
+++ b/accelerator/migrations/0054_update_eventbrite_organizer_id_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accelerator', '0053_add_eventbrite_organization_id_field'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='program',
+            old_name='eventbrite_organization_id',
+            new_name='eventbrite_organizer_id'
+        )
+    ]

--- a/accelerator_abstract/models/base_program.py
+++ b/accelerator_abstract/models/base_program.py
@@ -126,7 +126,7 @@ class BaseProgram(AcceleratorModel):
     overview_deadline_date = models.DateTimeField(
         blank=True, null=True,
         help_text="Time is in UTC")
-    eventbrite_organization_id = models.CharField(
+    eventbrite_organizer_id = models.CharField(
         max_length=20,
         blank=True,
         null=True)

--- a/accelerator_abstract/models/base_program.py
+++ b/accelerator_abstract/models/base_program.py
@@ -126,6 +126,10 @@ class BaseProgram(AcceleratorModel):
     overview_deadline_date = models.DateTimeField(
         blank=True, null=True,
         help_text="Time is in UTC")
+    eventbrite_organization_id = models.CharField(
+        max_length=20,
+        blank=True,
+        null=True)
     eventbrite_organizer_id = models.CharField(
         max_length=20,
         blank=True,


### PR DESCRIPTION
#### Changes introduced in [AC-6749](https://masschallenge.atlassian.net/browse/AC-6749)
- Rename feild eventbrite_organization_id to eventbrite_organizer_id
#### How to test
- Checkout this branch and run `make migrate` in accelerate
- Follow [this link](http://localhost:8181/admin/mc/program/23/change/)
- Notice that the eventbrite_organization_id field has changed to eventbrite_organizer_id
