### PR TITLE
AC-6754: Prevent the AC-6684 branch from automatically deploying to pre-staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 
 after_success:
 - >
-  if [ ! "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "development" ] || [ "$TRAVIS_BRANCH" = "AC-6678" ]; then
+  if [ ! "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$SANTE_GH_TOKEN";
     body='{


### PR DESCRIPTION
#### Changes introduced in [AC-6754](https://masschallenge.atlassian.net/browse/AC-6754)
ensure AC-6678 branch does not lead to auto-deployment

#### How to test
- A passing travis build and code change review should be enough to call this done.

#### Context
- this is a cleanup task from the [AC-6678](https://masschallenge.atlassian.net/browse/AC-6678) ticket