### PR TITLE
AC-6810: Correct logic in travis config to allow auto-deploy to pre-staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 
 after_success:
 - >
-  if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "6810" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "AC-6810" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$SANTE_GH_TOKEN";
     body='{

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,24 +28,9 @@ script:
 - make test
 - make code-check
 
-after_success:
-- >
-  if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "AC-6810" ]; then
-    gem install travis -v 1.8.10;
-    travis login --org --github-token "$SANTE_GH_TOKEN";
-    body='{
-    "request": {
-    "message": "Triggered by '$TRAVIS_COMMIT_MESSAGE' in django-accelerator",
-    "branch":"'$TRAVIS_BRANCH'",
-    "config": {
-      "script": "echo \"The tests dont need to run.\""
-      }
-    }}'
-    curl -s -X POST \
-      -H "Content-Type:application/json" \
-      -H "Accept:application/json" \
-      -H "Travis-API-Version:3" \
-      -H "Authorization:token $(travis token --org)" \
-      -d "$body" \
-      https://api.travis-ci.org/repo/masschallenge%2Fimpact-api/requests;
-  fi;
+deploy:
+  # deploy development to the pre-staging environment
+  - provider: script
+    script: bash scripts/pre-staging-deploy.sh
+    on:
+      branch: development

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
   - provider: script
     script: bash scripts/pre-staging-deploy.sh
     on:
-      branch: development
+      branch: AC-6810

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 
 after_success:
 - >
-  if [ ! "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "6810" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$SANTE_GH_TOKEN";
     body='{

--- a/scripts/pre-staging-deploy.sh
+++ b/scripts/pre-staging-deploy.sh
@@ -1,0 +1,20 @@
+gem install travis -v 1.8.10;
+
+travis login --org --github-token "$SANTE_GH_TOKEN";
+
+body='{
+"request": {
+"message": "Triggered by '$TRAVIS_COMMIT_MESSAGE' in django-accelerator",
+"branch":"'$TRAVIS_BRANCH'",
+"config": {
+"script": "echo \"The tests dont need to run.\""
+}
+}}'
+
+curl -s -X POST \
+-H "Content-Type:application/json" \
+-H "Accept:application/json" \
+-H "Travis-API-Version:3" \
+-H "Authorization:token $(travis token --org)" \
+-d "$body" \
+https://api.travis-ci.org/repo/masschallenge%2Fimpact-api/requests;


### PR DESCRIPTION
#### Changes introduced in [AC-6810](url)
- allow auto-deploy when branches are merged to development from
  a pr

#### How to test
Unfortunately this is one of those wait-and-see tickets. However I tested a few edge cases.

Note that in my examples below 
- `AC-6810` was acting as the dummy development branch
- to verify if an autodeply was **not** triggered, looking at the build log and seeing that the last command triggered took less than a second shows nothing happened.

> if a pr is raised from development to some other branch, is an auto-deploy triggered?

Nope, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/546863033) covering that. 

> if a pr is raised against development, is the deployed triggered then?

Nope, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/546865988) for that case

> if if push directly to development, is the deployment triggered then?

Yes, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/546863019) covering that. 

> if a pr is raised against development **and the pr is merged into development**, is a build triggered then?**

Yes! here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/546844326) covering that case. Notice that these trigger a deployment on ECS. You can see this from the bottom of the logs.