### PR TITLE
[AC-6800] Avoid routing to judge pages if not in active judging round

### DIFF
--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -37,6 +37,8 @@ UI_GENDER_CHOICES = (
     GENDER_PREFER_NOT_TO_STATE_CHOICE,
     GENDER_OTHER_CHOICE,
 )
+JUDGE_FIELDS_TO_LABELS = {'desired_judge_label': 'Desired Judge',
+                          'confirmed_judge_label': 'Judge'}
 
 
 @python_2_unicode_compatible
@@ -216,8 +218,23 @@ class BaseCoreProfile(AcceleratorModel):
         return self.default_page
 
     def calc_landing_page(self):
+        excludes = self._check_for_judge_excludes()
         return (self.startup_based_landing_page() or
-                self.role_based_landing_page())
+                self.role_based_landing_page(exclude_role_names=excludes))
+
+    def _check_for_judge_excludes(self):
+        excludes = []
+        for (label, role_name) in JUDGE_FIELDS_TO_LABELS.items():
+            if not self._has_judge_label_in_active_round(label):
+                excludes.append(role_name)
+        return excludes
+
+    def _has_judge_label_in_active_round(self, label):
+        JudgingRound = swapper.load_model(AcceleratorModel.Meta.app_label,
+                                          'JudgingRound')
+        active_rounds = JudgingRound.objects.filter(is_active=True)
+        label_ids = active_rounds.values_list(label, flat=True)
+        return self.user.userlabel_set.filter(id__in=label_ids).exists()
 
     def check_landing_page(self):
         page = self.landing_page or self.calc_landing_page()


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-6800

Note: unusually, the fix for this is on django-accelerator and the test is on accelerate. Should be obvious why once you look at both. 
Sibling PR: https://github.com/masschallenge/accelerate/pull/2223


Testing notes:
You'll need to find or construct a user with:
- mentor program role grant and judge program role grant in the same program
- no program role grants in programs ending after that program

`40355-user@example.com` is one such user. 

To see the error state, sign in as this user on development. You will be redirected to `/panels` but because the judging round is inactive, you will then be re-redirected to the expert profile page. 

To see the fixed state, check out branch AC-6800 and navigate to http://localhost:8181/ 
This will take you to the mentor dashboard for Switzerland, which is what the ticket asks for. 

QA will be a little persnickety here, as this work depends on an interaction between code state (specifically the path starting at `calc_landing_page`) and db state (including the landing_page of the program roles assigned to the judge and the existence or non- of the related fluent pages)
