### PR TITLE
AC-6810: Correct logic in travis config to allow auto-deploy to pre-staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ script:
 after_success:
 - printenv
 - >
-  if [ ! "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "AC-6810" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "AC-6810" ]; then
+    echo "here";
     gem install travis -v 1.8.10;
     travis login --org --github-token "$SANTE_GH_TOKEN";
     body='{

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
 - make code-check
 
 after_success:
+- printenv
 - >
   if [ ! "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 
 after_success:
 - >
-  if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "AC-6810" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$SANTE_GH_TOKEN";
     body='{


### PR DESCRIPTION
#### Changes introduced in [AC-6810](https://masschallenge.atlassian.net/browse/AC-6810)
- allow auto-deploy when branches are merged to development from a pr

#### How to test
Unfortunately this is one of those wait-and-see tickets. However I tested a few edge cases.

Note that in my examples below 
- `AC-6810` was acting as the dummy development branch
- to verify if an autodeply was **not** triggered, looking at the build log and seeing that the last command triggered took less than a second shows nothing happened.

> if a pr is raised from development to some other branch, is an auto-deploy triggered?

Nope, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/549654050) covering that. 

> if a pr is raised against development, is the deployed triggered then?

Nope, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/549168346) for that case

> if if push directly to development, is the deployment triggered then?

Yes, here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/549167182) covering that. Notice the [bottom of the py3 log](https://travis-ci.org/masschallenge/django-accelerator/jobs/549167184#L1349) where the condition evaluates to true

> if a pr is raised against development **and the pr is merged into development**, is a build triggered then?

Yes! here's the [build](https://travis-ci.org/masschallenge/django-accelerator/builds/549171406) covering that case. Notice that these trigger a deployment on ECS. You can see this from the [bottom of the logs](https://travis-ci.org/masschallenge/django-accelerator/jobs/549171408#L1212).