### PR TITLE
AC-1: Create an Algolia based Startup Directory on Accelerate for staff

### DIFF
--- a/accelerator/tests/contexts/startup_team_member_context.py
+++ b/accelerator/tests/contexts/startup_team_member_context.py
@@ -57,8 +57,17 @@ class StartupTeamMemberContext(object):
                 startup=self.startup,
                 startup_administrator=startup_administrator,
                 user=self.user)
+        self.startup_statuses = []
+        self.program_startup_statuses = []
+
         if startup_role:
-            StartupStatusFactory(
+            self.create_startup_status(startup_role)
+
+    def create_startup_status(self, startup_role):
+        startup_status = StartupStatusFactory(
                 program_startup_status__program=self.program,
                 program_startup_status__startup_role=startup_role,
                 startup=self.startup)
+        self.startup_statuses.append(startup_status)
+        self.program_startup_statuses.append(
+            startup_status.program_startup_status)

--- a/accelerator/tests/test_startup.py
+++ b/accelerator/tests/test_startup.py
@@ -15,7 +15,7 @@ from accelerator_abstract.models.base_startup_role import (
     BaseStartupRole
 )
 from accelerator_abstract.models.base_startup import (
-    ALGOLIA_STARTUP_STATUS
+    DISPLAY_STARTUP_STATUS
 )
 from accelerator.tests.contexts import (
     StartupTeamMemberContext
@@ -125,7 +125,7 @@ class TestStartup(TestCase):
             primary_contact=False,
             startup_role=startup_role)
         program = context.program
-        expected_status = ALGOLIA_STARTUP_STATUS.format(
+        expected_status = DISPLAY_STARTUP_STATUS.format(
             status=BaseStartupRole.FINALIST,
             year=program.start_date.year,
             program_family_slug=program.program_family.url_slug.upper()

--- a/accelerator/tests/test_startup.py
+++ b/accelerator/tests/test_startup.py
@@ -14,6 +14,9 @@ from accelerator.tests.factories import (
 from accelerator_abstract.models.base_startup_role import (
     BaseStartupRole
 )
+from accelerator_abstract.models.base_startup import (
+    ALGOLIA_STARTUP_STATUS
+)
 from accelerator.tests.contexts import (
     StartupTeamMemberContext
 )
@@ -116,12 +119,23 @@ class TestStartup(TestCase):
         self.assertFalse(
             context.startup.is_finalist(ProgramFactory()))
 
-    def test_generate_startup_status(self):
+    def test_generate_formatted_startup_status(self):
         startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
         context = StartupTeamMemberContext(
             primary_contact=False,
             startup_role=startup_role)
-        self.assertTrue(context.startup.is_finalist())
+        program = context.program
+        expected_status = ALGOLIA_STARTUP_STATUS.format(
+            status=BaseStartupRole.FINALIST,
+            year=program.start_date.year,
+            program_family_slug=program.program_family.url_slug.upper()
+        )
+        startup = context.startup
+        finalist_statuses = startup._get_finalist_startup_statuses()
+        self.assertEqual(
+            startup._generate_formatted_startup_status(finalist_statuses[0]),
+            expected_status
+        )
 
     def test_get_finalist_startup_statuses(self):
         startup_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
@@ -136,7 +150,7 @@ class TestStartup(TestCase):
             all([status in context.program_startup_statuses
                 for status in finalist_statuses]))
 
-    def test_finalist_startup_statuses(self):
+    def test_finalist_startup_statuses_are_in_order_of_date_created(self):
         finalist_role = StartupRoleFactory(name=BaseStartupRole.FINALIST)
         winner_role = StartupRoleFactory(name=BaseStartupRole.WINNER)
         context = StartupTeamMemberContext(
@@ -151,7 +165,7 @@ class TestStartup(TestCase):
         for status_string, status in zipped_lists:
             self.assertEqual(
                 status_string,
-                startup._generate_startup_status(status)
+                startup._generate_formatted_startup_status(status)
             )
 
     def test_latest_status_year_with_statuses(self):

--- a/accelerator/tests/test_startup.py
+++ b/accelerator/tests/test_startup.py
@@ -149,8 +149,8 @@ class TestStartup(TestCase):
             finalist_statuses, context.program_startup_statuses)
         startup = context.startup
         for status_string, status in zipped_lists:
-            self.assertTrue(
-                status_string ==
+            self.assertEqual(
+                status_string,
                 startup._generate_startup_status(status)
             )
 
@@ -162,14 +162,14 @@ class TestStartup(TestCase):
         startup = context.startup
         startup_status = context.startup_statuses[0].program_startup_status
         program_year = startup_status.program.start_date.year
-        self.assertTrue(startup.latest_status_year == program_year)
+        self.assertEqual(startup.latest_status_year, program_year)
 
     def test_latest_status_year_without_startup_status(self):
         context = StartupTeamMemberContext(
             primary_contact=False)
-        self.assertTrue(context.startup.latest_status_year == 0)
+        self.assertEqual(context.startup.latest_status_year, 0)
 
     def test_image_url_with_no_high_resolution_photo(self):
         context = StartupTeamMemberContext(
             primary_contact=False)
-        self.assertTrue(context.startup.image_url == "")
+        self.assertEqual(context.startup.image_url, "")

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -249,7 +249,9 @@ class BaseStartup(AcceleratorModel):
     @property
     def latest_status_year(self):
         statuses = self._generate_startup_status()
-        return statuses[0].program.start_date.year
+        if statuses:
+            return statuses[0].program.start_date.year
+        return 0
 
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -228,8 +228,7 @@ class BaseStartup(AcceleratorModel):
             "(" + status.program.program_family.url_slug.upper() + ")"
         )
 
-    @property
-    def finalist_startup_statuses(self):
+    def _get_finalist_startup_statuses(self):
         statuses_of_interest = (
             BaseStartupRole.FINALIST_STARTUP_ROLES +
             BaseStartupRole.WINNER_STARTUP_ROLES
@@ -237,10 +236,20 @@ class BaseStartup(AcceleratorModel):
         statuses = self.program_startup_statuses().filter(
                 startup_role__name__in=statuses_of_interest
                     ).order_by("-created_at")
+        return statuses
+
+    @property
+    def finalist_startup_statuses(self):
+        statuses = self._generate_startup_status()
         status_list = [
             self._generate_startup_status(status)
             for status in statuses]
         return list(status_list)
+
+    @property
+    def latest_status_year(self):
+        statuses = self._generate_startup_status()
+        return statuses[0].program.start_date.year
 
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -244,7 +244,7 @@ class BaseStartup(AcceleratorModel):
         status_list = [
             self._generate_startup_status(status)
             for status in statuses]
-        return list(status_list)
+        return status_list
 
     @property
     def latest_status_year(self):

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -240,7 +240,7 @@ class BaseStartup(AcceleratorModel):
         status_list = [
             self._generate_startup_status(status)
             for status in statuses]
-        return list(set(status_list))
+        return list(status_list)
 
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -217,10 +217,21 @@ class BaseStartup(AcceleratorModel):
 
     @property
     def finalist_startup_statuses(self):
+        statuses_of_interest = (
+            BaseStartupRole.FINALIST_STARTUP_ROLES +
+            BaseStartupRole.WINNER_STARTUP_ROLES
+        )
         statuses = self.program_startup_statuses().filter(
-                startup_role__name=BaseStartupRole.FINALIST).values_list(
-                    'program__name', flat=True).distinct()
-        return list(statuses)
+                startup_role__name__in=statuses_of_interest)
+        status_list = [
+            (
+                status.startup_role.name + " " +
+                str(status.program.start_date.year) + " " +
+                "(" + status.program.program_family.url_slug.upper() + ")"
+            )
+            for status in statuses]
+
+        return list(set(status_list))
 
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -29,7 +29,7 @@ STARTUP_COMMUNITIES = (
     ('green', 'Green'),
 )
 STARTUP_NO_ORG_WARNING_MSG = "Startup {} has no organization"
-ALGOLIA_STARTUP_STATUS = "{status} {year} ({program_family_slug})"
+DISPLAY_STARTUP_STATUS = "{status} {year} ({program_family_slug})"
 
 
 @python_2_unicode_compatible
@@ -224,7 +224,7 @@ class BaseStartup(AcceleratorModel):
 
     def _generate_formatted_startup_status(self, status):
         program = status.program
-        formatted_status = ALGOLIA_STARTUP_STATUS.format(
+        formatted_status = DISPLAY_STARTUP_STATUS.format(
             status=status.startup_role.name,
             year=str(program.start_date.year),
             program_family_slug=program.program_family.url_slug.upper()

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -240,7 +240,7 @@ class BaseStartup(AcceleratorModel):
 
     @property
     def finalist_startup_statuses(self):
-        statuses = self._generate_startup_status()
+        statuses = self._get_finalist_startup_statuses()
         status_list = [
             self._generate_startup_status(status)
             for status in statuses]
@@ -248,7 +248,7 @@ class BaseStartup(AcceleratorModel):
 
     @property
     def latest_status_year(self):
-        statuses = self._generate_startup_status()
+        statuses = self._get_finalist_startup_statuses()
         if statuses:
             return statuses[0].program.start_date.year
         return 0

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -215,6 +215,13 @@ class BaseStartup(AcceleratorModel):
         return ProgramStartupStatus.objects.filter(
             startupstatus__startup=self)
 
+    @property
+    def finalist_startup_statuses(self):
+        statuses = self.program_startup_statuses().filter(
+                startup_role__name=BaseStartupRole.FINALIST).values_list(
+                    'program__name', flat=True).distinct()
+        return list(statuses)
+
     def is_finalist(self, program=None):
         """if program is given, check whether this startup is a finalist
         in that program. Otherwise, check whether this startup is a finalist


### PR DESCRIPTION
#### Changes introduced in [AC-1](https://masschallenge.atlassian.net/browse/AC-1)
- add property functions for use in the new startup directory Algolia index and test them

#### How to test
- login as a staff user, our `+superuser` accounts should do for this
- visit https://test6.masschallenge.org/startups and see the new startup directory

#### Note
- There's a [line of code](https://github.com/masschallenge/django-accelerator/compare/development...AC-1#diff-b2f73bff9028b67f86a2b67c1114048fR214) not covered by tests, ideas about how to test this are too welcome because I haven't found a way yet
- this PR can be merged as is i.e. it has no travis dependencies