### PR TITLE
AC-6760: Ensure our automated processes depend on the MassChallenge Machine User

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ after_success:
 - >
   if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;
-    travis login --org --github-token "$SANTE_GH_TOKEN";
+    travis login --org --github-token "$MC_DEV_ADMIN_GH_TOKEN";
     body='{
     "request": {
     "message": "Triggered by '$TRAVIS_COMMIT_MESSAGE' in django-accelerator",


### PR DESCRIPTION
#### Changes introduced in [AC-6760](https://masschallenge.atlassian.net/browse/AC-6760)
- use mc admin token for travis build

#### How to test
- a passing travis build should be a good test for this

#### Note
This PR can be reviewed and merged independently of all it's siblings
 