### PR TITLE
AC-6874: Staff users with Entrepreneur profiles unable to view finalist dashboard pages

### DIFF
--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 from accelerator.tests.factories import (
     ExpertFactory,
+    EntrepreneurFactory,
     InterestCategoryFactory,
     MemberFactory,
     ProgramFactory,
@@ -214,3 +215,13 @@ class TestCoreProfile(TestCase):
         ])
         default_page = profile.default_page
         self.assertTrue(landing_page == default_page)
+
+    def test_entrepreneur_profile_has_confirmed_mentor_programs_prop(self):
+        mentor = EntrepreneurFactory()
+        attr = hasattr(mentor.get_profile(), "confirmed_mentor_programs")
+        self.assertTrue(attr)
+
+    def test_expert_profile_has_confirmed_mentor_programs_prop(self):
+        expert = ExpertFactory()
+        attr = hasattr(expert.get_profile(), "confirmed_mentor_programs")
+        self.assertTrue(attr)

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -250,3 +250,8 @@ class BaseCoreProfile(AcceleratorModel):
     def gender_value(self):
         gender_dict = dict(GENDER_CHOICES)
         return gender_dict[self.gender.lower()]
+
+    def confirmed_mentor_programs(self):
+        return list(self.user.programrolegrant_set.filter(
+            program_role__user_role__name=BaseUserRole.MENTOR).values_list(
+            'program_role__program__name', flat=True))


### PR DESCRIPTION
#### Changes introduced in [AC-6874]()
- move 'confirmed_mentor_programs' to the base core profile for Expert, Entrepreneur and Member profiles to use

#### How to test
- deploying to a test machine

#### Note
- there's a [sibling PR](https://github.com/masschallenge/accelerate/pull/2257) that should be merged **after** this one