### PR TITLE
AC-6895: Fix a travis config bug preventing continuous deployment to pre-staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ after_success:
   if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$MC_DEV_ADMIN_GH_TOKEN";
-    export TICKET_NUMBER = $(echo $TRAVIS_COMMIT_MESSAGE | grep -Eo AC-[0-9]+ | head -1);
+    export TICKET_NUMBER=$(echo $TRAVIS_COMMIT_MESSAGE | grep -Eo AC-[0-9]+ | head -1);
     body='{
     "request": {
     "message": "Triggered by '$TICKET_NUMBER' in django-accelerator",

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ after_success:
   if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "development" ]; then
     gem install travis -v 1.8.10;
     travis login --org --github-token "$MC_DEV_ADMIN_GH_TOKEN";
+    export TICKET_NUMBER = $(echo $TRAVIS_COMMIT_MESSAGE | grep -Eo AC-[0-9]+ | head -1);
     body='{
     "request": {
-    "message": "Triggered by '$TRAVIS_COMMIT_MESSAGE' in django-accelerator",
+    "message": "Triggered by '$TICKET_NUMBER' in django-accelerator",
     "branch":"'$TRAVIS_BRANCH'",
     "config": {
       "script": "echo \"The tests dont need to run.\""


### PR DESCRIPTION
#### Changes introduced in [AC-6895](https://masschallenge.atlassian.net/browse/AC-6895)
- fix travis config to allow continuous deploy to pre-staging

#### How to test
- unfortunately the only way to know if this works, is by actually merging the PR. If this change is successful, an impact-api build will be triggered which will lead to a pre-staging deployment