### PR TITLE
AC-6873 :: Mentors in a single program who have participated in previous years should not see program labels

### DIFF
--- a/accelerator/tests/contexts/__init__.py
+++ b/accelerator/tests/contexts/__init__.py
@@ -11,3 +11,5 @@ from accelerator.tests.contexts.startup_team_member_context import (
     StartupTeamMemberContext
 )
 from accelerator.tests.contexts.nav_tree_context import NavTreeContext
+
+from accelerator.tests.contexts.user_role_context import UserRoleContext

--- a/accelerator/tests/contexts/user_role_context.py
+++ b/accelerator/tests/contexts/user_role_context.py
@@ -1,0 +1,26 @@
+from builtins import object
+
+from accelerator.tests.factories import (
+    ExpertFactory,
+    ProgramFactory,
+    ProgramRoleFactory,
+    ProgramRoleGrantFactory,
+    UserRoleFactory,
+)
+
+
+class UserRoleContext(object):
+
+    def __init__(self, user_role_name, program=None, user=None):
+        if user and not program:
+            self.program = user.get_profile().current_program
+        else:
+            self.program = program or ProgramFactory()
+        self.user = (user or
+                     ExpertFactory(profile__current_program=self.program))
+        self.user_role = UserRoleFactory(name=user_role_name)
+        self.program_role = ProgramRoleFactory(user_role=self.user_role,
+                                               program=self.program)
+        self.program_role_grant = ProgramRoleGrantFactory(
+            person=self.user,
+            program_role=self.program_role)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -225,3 +225,9 @@ class TestCoreProfile(TestCase):
         expert = ExpertFactory()
         attr = hasattr(expert.get_profile(), "confirmed_mentor_programs")
         self.assertTrue(attr)
+
+    def test_expert_profile_has_cconfirmed_memtor_program_families_all_prop(self):
+        expert = ExpertFactory()
+        attr = hasattr(expert.get_profile(),
+                       "confirmed_memtor_program_families_all")
+        self.assertTrue(attr)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -16,12 +16,16 @@ from accelerator.tests.factories import (
     StartupFactory,
     UserRoleFactory,
     ProgramFamilyFactory,
-    PartnerTeamMemberFactory
+    PartnerTeamMemberFactory,
 )
 from accelerator_abstract.models import (
-    BaseUserRole
+    BaseUserRole,
+    ENDED_PROGRAM_STATUS,
 )
-from accelerator.tests.contexts import StartupTeamMemberContext
+from accelerator.tests.contexts import (
+    StartupTeamMemberContext,
+    UserRoleContext,
+)
 
 
 def expert(role):
@@ -232,3 +236,18 @@ class TestCoreProfile(TestCase):
         attr = hasattr(expert.get_profile(),
                        "confirmed_memtor_program_families_all")
         self.assertTrue(attr)
+
+    def test_user_profile_confirmed_mentor_program_families_method(self):
+        active_program = ProgramFactory()
+        inactive_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS)
+        user = EntrepreneurFactory()
+        UserRoleContext(
+            BaseUserRole.MENTOR,
+            user=user,
+            program=active_program)
+        UserRoleContext(
+            BaseUserRole.MENTOR,
+            user=user,
+            program=inactive_program)
+        families = user.get_profile().confirmed_memtor_program_families_all()
+        self.assertEqual(len(families), 2)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -251,3 +251,5 @@ class TestCoreProfile(TestCase):
             program=inactive_program)
         families = user.get_profile().confirmed_memtor_program_families_all()
         self.assertEqual(len(families), 2)
+        self.assertTrue(active_program.program_family.name in families)
+        self.assertTrue(inactive_program.program_family.name in families)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -226,7 +226,8 @@ class TestCoreProfile(TestCase):
         attr = hasattr(expert.get_profile(), "confirmed_mentor_programs")
         self.assertTrue(attr)
 
-    def test_expert_profile_has_cconfirmed_memtor_program_families_all_prop(self):
+    def test_expert_profile_has_confirmed_mentor_program_families_all_prop(
+            self):
         expert = ExpertFactory()
         attr = hasattr(expert.get_profile(),
                        "confirmed_memtor_program_families_all")

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -264,3 +264,9 @@ class BaseCoreProfile(AcceleratorModel):
         return list(self.user.programrolegrant_set.filter(
             program_role__user_role__name=BaseUserRole.MENTOR).values_list(
             'program_role__program__name', flat=True))
+
+    def confirmed_memtor_program_families_all(self):
+        return list(self.user.programrolegrant_set.filter(
+            program_role__user_role__name=BaseUserRole.MENTOR).values_list(
+                "program_role__program__program_family__name", flat=True
+        ).distinct())


### PR DESCRIPTION
**Changes introduced in [AC-6873](https://masschallenge.atlassian.net/browse/AC-6873)**
- add confirmed mentor program families to the base core profile, which returns even programs that ended.

**How to test:**
- Check out this branch 
- Masquerade as [user](http://localhost:8181/admin/simpleuser/user/844/masquerade/)
- Notice that they don't have a label on the `Mentor Dashboard` sub nav item despite having participated in previous years.

- Masquerade as [user](http://localhost:8181/admin/simpleuser/user/386/masquerade/)
- Notice that they are two `Mentor Dashboard` sub nav items with labels because they belong to different program families

**How to reproduce:**
- Masquerade as [user](http://localhost:8181/admin/simpleuser/user/844/masquerade/)
- Notice that the user  has a label on the `Mentor Dashboard` sub nav item because of having participated in previous year programs.