### PR TITLE
Ac 6909 - integrate code climate coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ python:
   - "3.6"
 cache: pip
 
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+
 services:
 - mysql
 
@@ -25,7 +30,8 @@ install:
 - git checkout $CURRENT_HEAD
 
 script:
-- make test
+- make coverage
+- make coverage-xml-report
 - make code-check
 
 after_success:
@@ -50,3 +56,6 @@ after_success:
       -d "$body" \
       https://api.travis-ci.org/repo/masschallenge%2Fimpact-api/requests;
   fi;
+
+after_script:
+- ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,10 @@ coverage-html-report: $(VENV)
 	@$(ACTIVATE); DJANGO_SETTINGS_MODULE=settings \
 	coverage html --omit="*/tests/*,*/venv/*"
 
+coverage-xml-report: $(VENV)
+  @$(ACTIVATE); DJANGO_SETTINGS_MODULE=settings \
+  coverage xml --omit="*/tests/*,*/venv/*"
+
 coverage-html: coverage
 	@open htmlcov/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ coverage-html-report: $(VENV)
 	coverage html --omit="*/tests/*,*/venv/*"
 
 coverage-xml-report: $(VENV)
-  @$(ACTIVATE); DJANGO_SETTINGS_MODULE=settings \
-  coverage xml --omit="*/tests/*,*/venv/*"
+	@$(ACTIVATE); DJANGO_SETTINGS_MODULE=settings \
+	coverage xml --omit="*/tests/*,*/venv/*"
 
 coverage-html: coverage
 	@open htmlcov/index.html

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/masschallenge/impact-api.svg?branch=development)](https://travis-ci.org/masschallenge/django-accelerator)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/2636b03b81f405b133f5/test_coverage)](https://codeclimate.com/github/masschallenge/django-accelerator/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2636b03b81f405b133f5/maintainability)](https://codeclimate.com/github/masschallenge/django-accelerator/maintainability)
 
 1. [Overview](#overview)
 2. [Quickstart](#quickstart)


### PR DESCRIPTION
To test:

- go to trqvis for this branch and re-trigger a build: https://travis-ci.org/masschallenge/django-accelerator/jobs/563735525#L1259
- see that the coverage report shows up at the bottom of code climate's coverage page: https://codeclimate.com/repos/5d31f01146abc2019e015ec2/settings/test_reporter


