### PR TITLE
removing insignificant line that breaks tests

### DIFF
--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -73,7 +73,6 @@ class User(AbstractUser):
         self.team_member = None
         self.profile = None
         self.user_finalist_roles = None
-        self.title = ""
 
     class AuthenticationException(Exception):
         pass


### PR DESCRIPTION
related PR: https://github.com/masschallenge/accelerate/pull/2309

Context on this - I noticed that a previously passing build for AC-6553 on impact started to fail. Herman confirmed Geofrey that it was due to a superflous line that was added. 