### PR TITLE
removing max version constraint for django

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-DJANGO_SPEC = ">=1.8"
+DJANGO_SPEC = ">=1.11,<=2.3"
 if "DJANGO_VERSION" in os.environ:
     DJANGO_SPEC = "=={}".format(os.environ["DJANGO_VERSION"])
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-DJANGO_SPEC = ">=1.8,<2.0"
+DJANGO_SPEC = ">=1.8"
 if "DJANGO_VERSION" in os.environ:
     DJANGO_SPEC = "=={}".format(os.environ["DJANGO_VERSION"])
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-DJANGO_SPEC = ">=1.11,<=2.3"
+DJANGO_SPEC = ">=1.11,<2.3"
 if "DJANGO_VERSION" in os.environ:
     DJANGO_SPEC = "=={}".format(os.environ["DJANGO_VERSION"])
 


### PR DESCRIPTION
This pr removes the max django version constraint of 2.0 from django-accelerator. This is so that we do not have to monkey patch the dockerfile in the django 2 branch as we continue work there. We should be able to safely merge this into development.