### PR TITLE
[AC-7033] Update django-accelerator Django version to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ help:
 	@echo
 
 
-DJANGO_VERSION = 1.11.18
+DJANGO_VERSION = 2.2.8
 VENV = venv
 ACTIVATE_SCRIPT = $(VENV)/bin/activate
 ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-DJANGO_SPEC = ">=1.11,<2.3"
+DJANGO_SPEC = ">=2.2,<2.3"
 if "DJANGO_VERSION" in os.environ:
     DJANGO_SPEC = "=={}".format(os.environ["DJANGO_VERSION"])
 
@@ -44,9 +44,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
## [AC-7033](https://masschallenge.atlassian.net/browse/AC-7033)

**Testing**: 
* In your local django-accelerator clone on this branch, run `rm -r venv && make test`
  * Confirm that Django 2 was in fact used: `. venv/bin/activate && python -c "import django; print(django.VERSION)"`
* Run `tox`, which will run the test suite under both Python 3.6 and Python 3.7.
  * Confirm that Django 2 was in fact used: Look for output like `py37 installed:...Django==2.2.8`