### PR TITLE
AC-7258 Run django-accelerator in a docker environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
 - echo $BRANCH
 - export CURRENT_HEAD=$(git rev-parse HEAD)
 - git checkout -b $DEFAULT_BRANCH || git checkout $DEFAULT_BRANCH
-- git pull origin $DEFAULT_BRANCH --no-edit
+- git branch
+- git pull origin $DEFAULT_BRANCH --no-edit --allow-unrelated-histories
 - git checkout -b $BRANCH || git checkout $BRANCH
 - git pull origin $BRANCH --no-edit
 - git checkout $CURRENT_HEAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
 - echo $BRANCH
 - export CURRENT_HEAD=$(git rev-parse HEAD)
 - git checkout -b $DEFAULT_BRANCH || git checkout $DEFAULT_BRANCH
-- git branch
-- git pull origin $DEFAULT_BRANCH --no-edit --allow-unrelated-histories
+- git pull origin $DEFAULT_BRANCH --no-edit
 - git checkout -b $BRANCH || git checkout $BRANCH
 - git pull origin $BRANCH --no-edit
 - git checkout $CURRENT_HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM accelerator_tests:latest
+
+WORKDIR /srv/www/mc/current
+
+COPY . /srv/www/mc/current
+
+CMD ["make", "coverage"]

--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,7 @@ target_help = \
   'setup - Sets up a Docker testing environent for django_accelerator' \
   'stop-server - Stops the Docker testing environent for django_accelerator' \
   'run - runs Makefile commands inside the Docker container.' \
-  '\tSet the "command" variable to one of:' \
-  '\t [help, package, clean, code-check, coverage, coverage-run, ' \
-  '\t coverage-report, coverage-html-report, coverage-xml-report, ' \
-  '\t install, uninstall, data-migration, migrations, test, tox] '\
-  '\t E.g. `make run command=test`' \
+  '\tSet the "command" variable e.g. `make run command=test`' \
   "bash-shell - Allows getting into the django_accelerator container's terminal" \
 
 OS = $(shell uname)

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,18 @@ target_help = \
   'deploy - Deploy $$(release_name) to a $$(target).' \
   '\tValid targets include "staging" (the default), "production",' \
   '\t "test-1", and "test-2"' \
+  ' ' \
+  'install-sqlite - Installs sqlite3 on Travis from a script in' \
+  '\t scripts/run_make_commands_in_docker.sh, however it also can run in the' \
+  '\t accelerator container' \
+  'build - Builds the image for django_accelerator' \
+  'setup - Sets up a docker testing environent for django_accelerator' \
+  'pull-down - Stops the docker testing environent for django_accelerator' \
+  'run - runs [help, package, clean, code-check, coverage, coverage-run, ' \
+  'coverage-report, coverage-html-report, coverage-xml-report, ' \
+  '\t coverage-html, install, uninstall, data-migration, migrations, ' \
+  '\t test, tox, install_sqlite] set of commands from the testing docker environent' \
+  "ssh - Allows getting into the django_accelerator container's terminal" \
 
 OS = $(shell uname)
 
@@ -196,3 +208,18 @@ migrate update-schema:
 
 checkout:
 	@$(IMPACT_MAKE) $@ branch=$(branch)
+
+build:
+	@docker build -f base.Dockerfile -t accelerator_tests .
+
+setup: build
+	@docker-compose up -d
+
+pull-down:
+	@docker-compose down
+
+run:
+	@docker-compose exec accelerator scripts/run_make_commands_in_docker.sh $(command)
+
+ssh:
+	@docker-compose exec accelerator /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ target_help = \
   '\tValid targets include "staging" (the default), "production",' \
   '\t "test-1", and "test-2"' \
   ' ' \
-  'install-sqlite - Installs sqlite3 on Travis from a script in' \
   '\t scripts/run_make_commands_in_docker.sh, however it also can run in the' \
   '\t accelerator container' \
   'build - Builds the Docker image for django_accelerator' \
@@ -88,8 +87,8 @@ target_help = \
   '\tSet the "command" variable to one of:' \
   '\t [help, package, clean, code-check, coverage, coverage-run, ' \
   '\t coverage-report, coverage-html-report, coverage-xml-report, ' \
-  '\t coverage-html, install, uninstall, data-migration, migrations, ' \
-  '\t test, tox, install_sqlite] E.g. `make run command=test`' \
+  '\t install, uninstall, data-migration, migrations, test, tox] '\
+  '\t E.g. `make run command=test`' \
   "bash-shell - Allows getting into the django_accelerator container's terminal" \
 
 OS = $(shell uname)

--- a/Makefile
+++ b/Makefile
@@ -81,14 +81,16 @@ target_help = \
   'install-sqlite - Installs sqlite3 on Travis from a script in' \
   '\t scripts/run_make_commands_in_docker.sh, however it also can run in the' \
   '\t accelerator container' \
-  'build - Builds the image for django_accelerator' \
+  'build - Builds the Docker image for django_accelerator' \
   'setup - Sets up a docker testing environent for django_accelerator' \
-  'pull-down - Stops the docker testing environent for django_accelerator' \
-  'run - runs [help, package, clean, code-check, coverage, coverage-run, ' \
-  'coverage-report, coverage-html-report, coverage-xml-report, ' \
+  'stop-server - Stops the Docker testing environent for django_accelerator' \
+  'run - runs Makefile commands inside the Docker container.' \
+  '\tSet the "command" variable to one of:' \
+  '\t [help, package, clean, code-check, coverage, coverage-run, ' \
+  '\t coverage-report, coverage-html-report, coverage-xml-report, ' \
   '\t coverage-html, install, uninstall, data-migration, migrations, ' \
-  '\t test, tox, install_sqlite] set of commands from the testing docker environent' \
-  "ssh - Allows getting into the django_accelerator container's terminal" \
+  '\t test, tox, install_sqlite] E.g. `make run command=test`' \
+  "bash-shell - Allows getting into the django_accelerator container's terminal" \
 
 OS = $(shell uname)
 
@@ -215,11 +217,11 @@ build:
 setup: build
 	@docker-compose up -d
 
-pull-down:
+stop-server:
 	@docker-compose down
 
 run:
 	@docker-compose exec accelerator scripts/run_make_commands_in_docker.sh $(command)
 
-ssh:
+bash-shell:
 	@docker-compose exec accelerator /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ target_help = \
   '\t scripts/run_make_commands_in_docker.sh, however it also can run in the' \
   '\t accelerator container' \
   'build - Builds the Docker image for django_accelerator' \
-  'setup - Sets up a docker testing environent for django_accelerator' \
+  'setup - Sets up a Docker testing environent for django_accelerator' \
   'stop-server - Stops the Docker testing environent for django_accelerator' \
   'run - runs Makefile commands inside the Docker container.' \
   '\tSet the "command" variable to one of:' \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:14.04
+
+WORKDIR /srv/www/mc/current
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&  \
+    useradd -s /bin/bash -u 3000 -m accelerate_user && \
+    chown -R accelerate_user /home/accelerate_user && \
+    chown -R accelerate_user /srv/www/mc/current
+
+RUN apt-get update -y && apt-get install sudo software-properties-common python-software-properties -y  && \
+    add-apt-repository ppa:saiarcot895/myppa && \
+    apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y apt-fast && \
+    apt-fast -y install git openssh-server build-essential libssl-dev zlib1g-dev libncurses5-dev libncursesw5-dev libreadline-dev libgdbm-dev libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev tk-dev libffi-dev && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y build-essential checkinstall apt-utils wget curl python3.6 python3.6-dev && \
+    apt-get install -y aria2 --no-install-recommends && \
+    curl https://bootstrap.pypa.io/get-pip.py | python3.6 && \
+    apt-get install -y cachefilesd && \
+    echo "RUN=yes" > /etc/default/cachefilesd && \
+    chown -R accelerate_user /var/lib/ && \
+    sed -i  '/requiretty/s/^/#/'  /etc/sudoers && \
+    echo "accelerate_user ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "accelerate_user -  nofile 65535" >> /etc/security/limits.conf && \
+    apt-fast -y install python-setuptools python-dev emacs24 libjpeg8-dev
+
+RUN sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.4 1 && \
+    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 2 && \
+    sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  accelerator:
+    container_name: accelerator-container
+    build: 
+      context: .
+    volumes:
+      - ${PWD}:/srv/www/mc/current:cached
+    user: root
+    stdin_open: true
+    tty: true
+    command: >
+        /bin/bash

--- a/scripts/run_make_commands_in_docker.sh
+++ b/scripts/run_make_commands_in_docker.sh
@@ -38,14 +38,11 @@ set_expected_commands (){
         coverage-report
         coverage-html-report
         coverage-xml-report
-        coverage-html
         install
         uninstall
         data-migration
         migrations
         test
-        tox
-        install_sqlite
     )
 }
 

--- a/scripts/run_make_commands_in_docker.sh
+++ b/scripts/run_make_commands_in_docker.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# set colors for text
+BOLD='\e[1m'
+BLUE='\e[34m'
+RED='\e[31m'
+YELLOW='\e[33m'
+GREEN='\e[92m'
+NC='\e[0m'
+
+# set text formats
+info() {
+    printf "\n${BOLD}${BLUE}====> $(echo $@ ) ${NC}\n"
+}
+
+warning () {
+    printf "\n${BOLD}${YELLOW}====> $(echo $@ )  ${NC}\n"
+}
+
+error() {
+    printf "\n${BOLD}${RED}====> $(echo $@ )  ${NC}\n"
+    bash -c "exit 1"
+}
+
+success () {
+    printf "\n${BOLD}${GREEN}====> $(echo $@ ) ${NC}\n"
+}
+
+# restrict and set expected make commands in django-accelerator
+set_expected_commands (){
+    VARIABLES+=(
+        help
+        package
+        clean
+        code-check
+        coverage
+        coverage-run
+        coverage-report
+        coverage-html-report
+        coverage-xml-report
+        coverage-html
+        install
+        uninstall
+        data-migration
+        migrations
+        test
+        tox
+        install_sqlite
+    )
+}
+
+
+set_expected_commands
+for variable in ${VARIABLES[@]}; do
+    if [[ $1 == $variable ]]; then
+        echo "---running--"
+        make $1
+        success "Done..."
+        exit 0
+    fi
+done
+
+warning "[ make run command=<command> ] does not support \"$1\" command"

--- a/simpleuser/tests/test_models.py
+++ b/simpleuser/tests/test_models.py
@@ -94,11 +94,11 @@ class TestUser(TestCase):
     def test_startup_team_member_has_a_startup(self):
         user = UserFactory()
         member = StartupTeamMemberFactory(user=user)
-        self.assertEquals(user.startup_name(), member.startup.name)
+        self.assertEqual(user.startup_name(), member.startup.name)
 
     def test_user_without_a_startup(self):
         user = UserFactory()
-        self.assertEquals(user.startup_name(), None)
+        self.assertEqual(user.startup_name(), None)
 
     def test_expert_has_a_user_title(self):
         expert = ExpertFactory()


### PR DESCRIPTION
### Changes introduced in: [AC-7258](https://masschallenge.atlassian.net/browse/AC-7258):
- Runs django-accelerator in docker

### How to test
- run `make setup` to setup the docker environment
- run `make run command=<any make command in the Makefile>` like `make run command=test`
- run `make stop-server` to stop the container
- run `make bash-shell` to get into the running container