### PR TITLE
[AC-7325] Django Security release, severity "high"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ help:
 	@echo
 
 
-DJANGO_VERSION = 1.11.18
+DJANGO_VERSION = 1.11.27
 VENV = venv
 ACTIVATE_SCRIPT = $(VENV)/bin/activate
 ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)


### PR DESCRIPTION
### Changes introduced in: [AC-7325](https://masschallenge.atlassian.net/browse/AC-7325):
- Bumps up django version

### How to test
- Travis build with Django 1.11.27 does not fail

local testing
- Follow testing instructions on [accelerate](https://github.com/masschallenge/accelerate/pull/2480)