### PR TITLE
[AC-7340] Fix local build of AC-6999

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ INSTALL_REQUIRES = [
     "pillow",
     "pytz",
     "swapper",
-    "django-ordered-model==2.1.0",
+    "django-ordered-model",
     "django-paypal==1.0.0",
     "django-fluent-pages==2.0.6",
     "django-polymorphic",


### PR DESCRIPTION
## [AC-7340](https://masschallenge.atlassian.net/browse/AC-7340)

From the ticket: I smoke-tested this by checking out `development` on accelerate, manually editing the django-accelerator code in my container, running `bin/buildout`, and checking that the build was usable (`bin/django` existed; I was able to run tests).

We need this for Django 2, but it's a change being made to the main line (because of how our local build process works), so I wanted confidence that it doesn't break things under Django 1.