### PR TITLE
[AC-5722] Change log level for tests to eliminate warning output (Lab Day PR)

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -6,7 +6,7 @@ import sys
 import logging
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
-    logging.disable(logging.INFO)
+    logging.disable(logging.WARNING)
 
 PACKAGE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                             "accelerator"))


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-5722

This PR just changes the logging disable level to provide clean output when running tests on django-accelerator. 

Keeping "ERROR" and "CRITICAL" since we should hope we won't see those in tests, and we'd want to know if we were triggering those in the course of day-to-day operations. 

If we add tests that throw those logs, we can revisit that choice. 

To test: run tests. On development, see

```
..........................Missing BaseProfile for user user_13@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
.....................................................................................................................................Startup None has no organization
Startup None has no organization
Startup None has no organization
Startup 1 has no organization
.Startup None has no organization
Startup None has no organization
Startup None has no organization
Startup 1 has no organization
.Startup None has no organization
Startup None has no organization
Startup None has no organization
Startup 1 has no organization
.......................................................Missing BaseProfile for user user_164@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
.....Missing BaseProfile for user user_173@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
.Missing BaseProfile for user user_175@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
........Missing BaseProfile for user user_187@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
.Missing BaseProfile for user user_188@example.com. Creating.
No CoreProfile Subclass found. Creating a default profile of type 'MEMBER'
./Users/jpk/mc/django-accelerator/venv/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Program.start_date received a naive datetime (2005-06-01 00:00:00) while time zone support is active.
  RuntimeWarning)
.
----------------------------------------------------------------------
Ran 233 tests in 9.407s
```

On branch, see 

```
......................................................................................................................................................................................................................................../Users/jpk/mc/django-accelerator/venv/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField Program.start_date received a naive datetime (2005-06-01 00:00:00) while time zone support is active.
  RuntimeWarning)
.
----------------------------------------------------------------------
Ran 233 tests in 7.415s

```