### PR TITLE
[AC-6883] Question and Application question admin pages include help text for adding "|"

### DIFF
--- a/accelerator_abstract/models/accelerator_model.py
+++ b/accelerator_abstract/models/accelerator_model.py
@@ -5,6 +5,10 @@ from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
+CHOICE_OPTION_HELP_TEXT = (
+    "Provide a list of options separated by a “|” (ie. Yes|No)"
+)
+
 
 @python_2_unicode_compatible
 class AcceleratorModel(models.Model):

--- a/accelerator_abstract/models/base_application_question.py
+++ b/accelerator_abstract/models/base_application_question.py
@@ -7,7 +7,10 @@ import swapper
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from accelerator_abstract.models.accelerator_model import AcceleratorModel
+from accelerator_abstract.models.accelerator_model import (
+    AcceleratorModel,
+    CHOICE_OPTION_HELP_TEXT
+)
 from accelerator_abstract.models.base_question import (
     CHOICE_LAYOUTS,
     QUESTION_TYPES,
@@ -51,7 +54,11 @@ class BaseApplicationQuestion(AcceleratorModel):
         blank=True,
     )
     # To be removed:
-    choice_options = models.CharField(max_length=4000, blank=True)
+    choice_options = models.CharField(
+        max_length=4000,
+        blank=True,
+        help_text=CHOICE_OPTION_HELP_TEXT
+    )
     # To be removed:
     choice_layout = models.CharField(
         max_length=64,

--- a/accelerator_abstract/models/base_judging_form_element.py
+++ b/accelerator_abstract/models/base_judging_form_element.py
@@ -7,7 +7,10 @@ import swapper
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from accelerator_abstract.models.accelerator_model import AcceleratorModel
+from accelerator_abstract.models.accelerator_model import (
+    AcceleratorModel,
+    CHOICE_OPTION_HELP_TEXT
+)
 from accelerator_abstract.models.base_application_question import (
     CHOICE_LAYOUTS,
     TEXT_LIMIT_UNITS,
@@ -119,7 +122,11 @@ class BaseJudgingFormElement(AcceleratorModel):
         choices=TEXT_LIMIT_UNITS,
         blank=True,
     )
-    choice_options = models.CharField(max_length=200, blank=True)
+    choice_options = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text=CHOICE_OPTION_HELP_TEXT
+    )
     choice_layout = models.CharField(
         max_length=64,
         choices=CHOICE_LAYOUTS,

--- a/accelerator_abstract/models/base_question.py
+++ b/accelerator_abstract/models/base_question.py
@@ -5,7 +5,10 @@ from __future__ import unicode_literals
 
 from django.db import models
 
-from accelerator_abstract.models.accelerator_model import AcceleratorModel
+from accelerator_abstract.models.accelerator_model import (
+    AcceleratorModel,
+    CHOICE_OPTION_HELP_TEXT
+)
 
 CHOICE_LAYOUT_HORIZONTAL = "horizontal"
 CHOICE_LAYOUT_VERTICAL = "vertical"
@@ -30,7 +33,11 @@ class BaseQuestion(AcceleratorModel):
         max_length=64,
         choices=QUESTION_TYPES,
     )
-    choice_options = models.CharField(max_length=4000, blank=True)
+    choice_options = models.CharField(
+        max_length=4000,
+        blank=True,
+        help_text=CHOICE_OPTION_HELP_TEXT
+    )
     choice_layout = models.CharField(
         max_length=64,
         choices=CHOICE_LAYOUTS,


### PR DESCRIPTION
## [AC-6883](https://masschallenge.atlassian.net/browse/AC-6883)


**Changes Introduced:**

-  Add help text for choice options

**Testing:**
-  As an Admin: Visit [Question admin](http://localhost:8181/admin/mc/question/49/change/), [Application Question page](http://localhost:8181/admin/mc/applicationquestion/1/change/) and [Judging form element page](http://localhost:8181/admin/mc/judgingformelement/13/change/)
**Expected results:**
- You should be able to view a help text in all the choice options
Help text: 

> Provide a list of options separated by a “|” (ie. Yes|No)