### PR TITLE
[AC-7386] Apply Django security release 2.2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ help:
 	@echo
 
 
-DJANGO_VERSION = 2.2.9
+DJANGO_VERSION = 2.2.10
 VENV = venv
 ACTIVATE_SCRIPT = $(VENV)/bin/activate
 ACTIVATE = export PYTHONPATH=.; . $(ACTIVATE_SCRIPT)


### PR DESCRIPTION
### Changes introduced in: [AC-7386](https://masschallenge.atlassian.net/browse/AC-7386):
- Bumps up django version
### How to test(Travis)
- Travis build with Django 2.2.10 does not fail
### How to test(Locally)
- Follow testing instructions on the [accelerate](https://github.com/masschallenge/accelerate/pull/2480) PR