### PR TITLE
[AC-7517] add ALUM to base startup role model

### DIFF
--- a/accelerator/tests/test_base_user_role.py
+++ b/accelerator/tests/test_base_user_role.py
@@ -3,7 +3,11 @@
 
 from django.test import TestCase
 
-from accelerator.tests.contexts import JudgeFeedbackContext
+from accelerator.tests.contexts import (
+    JudgeFeedbackContext,
+    UserRoleContext,
+)
+from accelerator_abstract.models.base_user_role import has_user_roles
 from accelerator.models import (
     has_user_role_base,
     UserRole,
@@ -18,3 +22,9 @@ class TestBaseUserRole(TestCase):
                                            UserRole.JUDGE,
                                            inactive_programs=True,
                                            active_or_ended_programs=True))
+
+    def test_has_user_roles(self):
+        context = UserRoleContext(user_role_name=UserRole.FINALIST)
+        user = context.user
+        self.assertTrue(has_user_roles(user,
+                                       [UserRole.ALUM, UserRole.FINALIST]))

--- a/accelerator/tests/test_base_user_role.py
+++ b/accelerator/tests/test_base_user_role.py
@@ -23,8 +23,14 @@ class TestBaseUserRole(TestCase):
                                            inactive_programs=True,
                                            active_or_ended_programs=True))
 
-    def test_has_user_roles(self):
+    def test_has_user_roles_is_true_when_role_exists(self):
         context = UserRoleContext(user_role_name=UserRole.FINALIST)
         user = context.user
         self.assertTrue(has_user_roles(user,
                                        [UserRole.ALUM, UserRole.FINALIST]))
+
+    def test_has_user_roles_is_false_when_role_does_not_exists(self):
+        context = UserRoleContext(user_role_name=UserRole.MENTOR)
+        user = context.user
+        self.assertFalse(has_user_roles(user,
+                                        [UserRole.ALUM, UserRole.FINALIST]))

--- a/accelerator_abstract/models/base_startup_role.py
+++ b/accelerator_abstract/models/base_startup_role.py
@@ -24,6 +24,7 @@ class BaseStartupRole(AcceleratorModel):
     DIAMOND_WINNER = "Diamond Winner"
     IN_KIND_WINNER = "In-Kind Winner"
     SIDECAR_WINNER = "Sidecar Winner"
+    ALUM = "Alum"
 
     FINALIST_STARTUP_ROLES = [FINALIST,
                               AIR,

--- a/accelerator_abstract/models/base_user_role.py
+++ b/accelerator_abstract/models/base_user_role.py
@@ -76,3 +76,8 @@ def is_mentor(user, program=None, inactive_programs=False):
 def is_judge(user, program=None, inactive_programs=False):
     return has_user_role_base(
         user, BaseUserRole.JUDGE, program, inactive_programs)
+
+
+def has_user_roles(user, roles=None):
+    return user.programrolegrant_set.filter(
+        program_role__user_role__name__in=roles).exists()


### PR DESCRIPTION
## [AC-7517](https://masschallenge.atlassian.net/browse/AC-7517)

**Changes Introduced:**
- add ALUM to base startup role model

**Testing**
- checkout to `AC-7517` in `django-accelerator` and `accelerate`.
- Navigate to any startup preview page with the following roles: [entrant, finalist, winner, or alumni]

Check for: 
- `Entrant` labels are visible to staff only
- All other labels are visible to staff, experts, finalists, and alumni 
- Under the heading Participation, display programs the startup in which the startup is/has been an entrant, finalist, winner, or alumni as list items under the heading
- Labels follow the format `year + status`, for example, **2017 Finalist**
- If `alumni` in `program_name`, finalist tag is not displayed in the same program
- The most recent is displayed first

[sibling PR](https://github.com/masschallenge/accelerate/pull/2572)