### PR TITLE
AC-7723 Too-long 'topics' field in OfficeHoursReservationView should not throw a 500

### DIFF
--- a/accelerator/migrations/023_alter_topics_field_office_hours.py
+++ b/accelerator/migrations/023_alter_topics_field_office_hours.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='mentorprogramofficehour',
             name='topics',
-            field=models.TextField(blank=True),
+            field=models.CharField(blank=True, default='', max_length=2000),
         ),
     ]

--- a/accelerator/migrations/023_alter_topics_field_office_hours.py
+++ b/accelerator/migrations/023_alter_topics_field_office_hours.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accelerator', '0022_add_meeting_info_on_office_hour_model'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='mentorprogramofficehour',
+            name='topics',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/accelerator_abstract/models/base_mentor_program_office_hour.py
+++ b/accelerator_abstract/models/base_mentor_program_office_hour.py
@@ -48,7 +48,7 @@ class BaseMentorProgramOfficeHour(AcceleratorModel):
         blank=True,
         on_delete=models.CASCADE)
     notify_reservation = models.BooleanField(default=True)
-    topics = models.TextField(blank=True)
+    topics = models.CharField(max_length=2000, blank=True, default="")
     meeting_info = models.CharField(max_length=256, blank=True, default="")
 
     class Meta(AcceleratorModel.Meta):

--- a/accelerator_abstract/models/base_mentor_program_office_hour.py
+++ b/accelerator_abstract/models/base_mentor_program_office_hour.py
@@ -48,7 +48,7 @@ class BaseMentorProgramOfficeHour(AcceleratorModel):
         blank=True,
         on_delete=models.CASCADE)
     notify_reservation = models.BooleanField(default=True)
-    topics = models.CharField(max_length=500, blank=True)
+    topics = models.TextField(blank=True)
     meeting_info = models.CharField(max_length=256, blank=True, default="")
 
     class Meta(AcceleratorModel.Meta):


### PR DESCRIPTION
### Changes Introduced in [AC-7723 ](https://masschallenge.atlassian.net/browse/AC-7723 ):
- Remove the character limit on the topics field
### Testing:
- Check out this branch
- Visit the office hours page for Boston 2019 [here](http://localhost:8181/officehours/bos/2019/)
- Schedule office hours
- Try reserving office hours for a finalist.
- Notice that there is a limit of 2000 chars on Meeting information