### PR TITLE
[AC-7987-fix] removing version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
     "django-paypal==1.0.0",
     "django-fluent-pages==2.0.6",
     "django-polymorphic",
-    "django-sitetree==1.15.1"
+    "django-sitetree"
 ]
 
 setup(


### PR DESCRIPTION
This removes the version pin for django sitetree. 

to test:

- Checkout this branch on django accelerator
- ssh into the accelerate container and re-run bin/buildout and confirm it succeeds