### PR TITLE
[AC-8200] Validate judge feedback form

### DIFF
--- a/accelerator/tests/contexts/judge_feedback_context.py
+++ b/accelerator/tests/contexts/judge_feedback_context.py
@@ -190,7 +190,9 @@ class JudgeFeedbackContext:
                     mandatory=True,
                     text_minimum=0,
                     text_minimum_units="",
-                    answer_text=None):
+                    answer_text=None,
+                    text_limit=0,
+                    text_limit_units=""):
         element = JudgingFormElementFactory(
             form_type=self.judging_form,
             mandatory=mandatory,
@@ -200,7 +202,9 @@ class JudgeFeedbackContext:
             sharing="share-with-startup",
             application_question__application_type=self.application_type,
             text_minimum=text_minimum,
-            text_minimum_units=text_minimum_units
+            text_minimum_units=text_minimum_units,
+            text_limit=text_limit,
+            text_limit_units=text_limit_units,
         )
         application_question = element.application_question
         self.application_questions.append(application_question)

--- a/accelerator_abstract/models/base_judge_application_feedback.py
+++ b/accelerator_abstract/models/base_judge_application_feedback.py
@@ -63,6 +63,9 @@ class BaseJudgeApplicationFeedback(AcceleratorModel):
     MANDATORY_MESSAGE = 'The question "%s" is mandatory.'
     REQUIRED_MINIMUM_MESSAGE = 'The question "%s" requires a minimum of %s %s.'
     STR_FORMAT = 'Feedback to Application %s by Judge %s'
+    REQUIRED_MAXIMUM_MESSAGE = 'The question "%s" requires a maximum of %s %s.'
+    REQUIRED_CHARACTER_SET_MESSAGE = 'The question "%s" must be in English text'
+
 
     class Meta(AcceleratorModel.Meta):
         db_table = '{}_judgeapplicationfeedback'.format(

--- a/accelerator_abstract/models/base_judge_application_feedback.py
+++ b/accelerator_abstract/models/base_judge_application_feedback.py
@@ -64,8 +64,8 @@ class BaseJudgeApplicationFeedback(AcceleratorModel):
     REQUIRED_MINIMUM_MESSAGE = 'The question "%s" requires a minimum of %s %s.'
     STR_FORMAT = 'Feedback to Application %s by Judge %s'
     REQUIRED_MAXIMUM_MESSAGE = 'The question "%s" requires a maximum of %s %s.'
-    REQUIRED_CHARACTER_SET_MESSAGE = 'The question "%s" must be in English text'
-
+    REQUIRED_CHARACTER_SET_MESSAGE = ('The question "%s" must be in English'
+                                      ' text')
 
     class Meta(AcceleratorModel.Meta):
         db_table = '{}_judgeapplicationfeedback'.format(


### PR DESCRIPTION
## [AC-8200](https://masschallenge.atlassian.net/browse/AC-8200)

**Changes introduced**
- Validate judge feedback form

**How to test**
- Checkout to this branch on `accelerate` and `django-accelerator`
- As a staff user, set the following judging rounds as active and in the present:[judging round 69](http://localhost:8181/admin/mc/judginground/69/), [judging round 74](http://localhost:8181/admin/mc/judginground/74/)
- Set [panel](http://localhost:8181/admin/mc/panel/77556/) to ACTIVE.
```
on django shell:
from mc.models import User
u = User.objects.get(email='sdavis@cxoadvisorygroup.com')
u.set_password('yourtestpass'); u.save()
```
- Login as sdavis@cxoadvisorygroup.com
- Go to http://localhost:8181/feedback/386/77556/15258/
- Confirm this ticket meets the definition of done according to [AC-8200](https://masschallenge.atlassian.net/browse/AC-8200)
  - In order to test character/words limits, you'll have to set them on admin panel or django console. Example: To set character limits for "Written Feedback to the Startup"
```
from mc.models import JudgingFormElement

jfe = JudgingFormElement.objects.get(pk=1214)

// example: Answer should not exceed 1000 characters
jfe.text_limit = 1000
jfe.text_limit_units = 'characters' 

// example: Answer should exceed 10 words
jfe.text_minimum = 10
jfe.text_minimum_units = 'words'
jfe.save()
```

[Sibling PR](https://github.com/masschallenge/accelerate/pull/2770)