### PR TITLE
AC-7856 - Replace instances of AcceleratorConfig.name with a constant

### DIFF
--- a/accelerator/models/profile_query_set.py
+++ b/accelerator/models/profile_query_set.py
@@ -1,8 +1,5 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
-
-from __future__ import unicode_literals
-
 import logging
 
 from django.contrib.auth import get_user_model
@@ -14,18 +11,13 @@ from accelerator_abstract.models.base_base_profile import (
     EXPERT_USER_TYPE,
     MEMBER_USER_TYPE,
 )
-from accelerator.apps import AcceleratorConfig
 
 import swapper
 
-EntrepreneurProfile = swapper.load_model(AcceleratorConfig.name,
-                                         "EntrepreneurProfile")
-ExpertProfile = swapper.load_model(AcceleratorConfig.name,
-                                   "ExpertProfile")
-MemberProfile = swapper.load_model(AcceleratorConfig.name,
-                                   "MemberProfile")
-BaseProfile = swapper.load_model(AcceleratorConfig.name,
-                                 "BaseProfile")
+EntrepreneurProfile = swapper.load_model('accelerator', "EntrepreneurProfile")
+ExpertProfile = swapper.load_model('accelerator', "ExpertProfile")
+MemberProfile = swapper.load_model('accelerator', "MemberProfile")
+BaseProfile = swapper.load_model('accelerator', "BaseProfile")
 User = get_user_model()
 
 MISSING_BASE_PROFILE_TEMPLATE = ("Missing BaseProfile for user {}. "

--- a/accelerator/tests/contexts/analyze_judging_context.py
+++ b/accelerator/tests/contexts/analyze_judging_context.py
@@ -8,12 +8,10 @@ from accelerator.tests.contexts.judge_feedback_context import (
 from accelerator.models import (
     JUDGING_FEEDBACK_STATUS_COMPLETE,
 )
-from accelerator.apps import AcceleratorConfig
 import swapper
 
 
-JudgeApplicationFeedback = swapper.load_model(
-    AcceleratorConfig.name,
+JudgeApplicationFeedback = swapper.load_model('accelerator',
     'JudgeApplicationFeedback')
 
 

--- a/accelerator/tests/contexts/analyze_judging_context.py
+++ b/accelerator/tests/contexts/analyze_judging_context.py
@@ -5,14 +5,13 @@ from accelerator.tests.factories import (
 from accelerator.tests.contexts.judge_feedback_context import (
     JudgeFeedbackContext,
 )
-from accelerator.models import (
-    JUDGING_FEEDBACK_STATUS_COMPLETE,
-)
+from accelerator.models import JUDGING_FEEDBACK_STATUS_COMPLETE
+
 import swapper
 
 
-JudgeApplicationFeedback = swapper.load_model('accelerator',
-    'JudgeApplicationFeedback')
+JudgeApplicationFeedback = swapper.load_model(
+    'accelerator', 'JudgeApplicationFeedback')
 
 
 class AnalyzeJudgingContext(JudgeFeedbackContext):

--- a/accelerator/tests/factories/allocator_factory.py
+++ b/accelerator/tests/factories/allocator_factory.py
@@ -8,15 +8,13 @@ from factory import SubFactory
 
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory,
 )
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
 
-Allocator = swapper.load_model(AcceleratorConfig.name, 'Allocator')
+Allocator = swapper.load_model('accelerator', 'Allocator')
 
 
 class AllocatorFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/application_answer_factory.py
+++ b/accelerator/tests/factories/application_answer_factory.py
@@ -10,14 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_factory import ApplicationFactory
 from accelerator.tests.factories.application_question_factory import (
     ApplicationQuestionFactory
 )
 
-ApplicationAnswer = swapper.load_model(AcceleratorConfig.name,
-                                       'ApplicationAnswer')
+ApplicationAnswer = swapper.load_model('accelerator', 'ApplicationAnswer')
 
 
 class ApplicationAnswerFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/application_factory.py
+++ b/accelerator/tests/factories/application_factory.py
@@ -13,7 +13,6 @@ from factory import SubFactory
 from factory.django import DjangoModelFactory
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_type_factory import (
     ApplicationTypeFactory
 )
@@ -25,8 +24,7 @@ from accelerator_abstract.models.base_application import (
     INCOMPLETE_APP_STATUS,
 )
 
-Application = swapper.load_model(AcceleratorConfig.name,
-                                 'Application')
+Application = swapper.load_model('accelerator', 'Application')
 
 
 class ApplicationFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/application_panel_assignment_factory.py
+++ b/accelerator/tests/factories/application_panel_assignment_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_factory import ApplicationFactory
 from accelerator.tests.factories.panel_factory import PanelFactory
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
-ApplicationPanelAssignment = swapper.load_model(AcceleratorConfig.name,
+ApplicationPanelAssignment = swapper.load_model('accelerator',
                                                 'ApplicationPanelAssignment')
 
 

--- a/accelerator/tests/factories/application_question_factory.py
+++ b/accelerator/tests/factories/application_question_factory.py
@@ -10,13 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_type_factory import (
     ApplicationTypeFactory
 )
 from accelerator.tests.factories.question_factory import QuestionFactory
 
-ApplicationQuestion = swapper.load_model(AcceleratorConfig.name,
+ApplicationQuestion = swapper.load_model('accelerator',
                                          'ApplicationQuestion')
 
 

--- a/accelerator/tests/factories/application_type_factory.py
+++ b/accelerator/tests/factories/application_type_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.startup_label_factory import (
     StartupLabelFactory
 )
 
-ApplicationType = swapper.load_model(AcceleratorConfig.name, 'ApplicationType')
+ApplicationType = swapper.load_model('accelerator', 'ApplicationType')
 
 
 class ApplicationTypeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/base_profile_factory.py
+++ b/accelerator/tests/factories/base_profile_factory.py
@@ -6,10 +6,9 @@ from __future__ import unicode_literals
 import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
-from accelerator.apps import AcceleratorConfig
 from simpleuser.tests.factories.user_factory import UserFactory
 
-BaseProfile = swapper.load_model(AcceleratorConfig.name, 'BaseProfile')
+BaseProfile = swapper.load_model('accelerator', 'BaseProfile')
 
 
 class BaseProfileFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/bucket_state_factory.py
+++ b/accelerator/tests/factories/bucket_state_factory.py
@@ -13,7 +13,6 @@ from factory import SubFactory
 from factory.django import DjangoModelFactory
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     STALE_NOSTARTUP_BUCKET_TYPE,
     STALE_LEADS_GROUP,
@@ -24,7 +23,7 @@ from accelerator.tests.factories.program_cycle_factory import (
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.program_role_factory import ProgramRoleFactory
 
-BucketState = swapper.load_model(AcceleratorConfig.name, 'BucketState')
+BucketState = swapper.load_model('accelerator', 'BucketState')
 
 
 class BucketStateFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/clearance_factory.py
+++ b/accelerator/tests/factories/clearance_factory.py
@@ -8,14 +8,13 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import CLEARANCE_LEVEL_POM
 from accelerator.tests.factories.program_family_factory import (
     ProgramFamilyFactory
 )
 from simpleuser.tests.factories.user_factory import UserFactory
 
-Clearance = swapper.load_model(AcceleratorConfig.name, 'Clearance')
+Clearance = swapper.load_model('accelerator', 'Clearance')
 
 
 class ClearanceFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/criterion_factory.py
+++ b/accelerator/tests/factories/criterion_factory.py
@@ -9,11 +9,10 @@ from factory import (
     SubFactory,
 )
 from factory.django import DjangoModelFactory
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
-Criterion = swapper.load_model(AcceleratorConfig.name, 'Criterion')
+Criterion = swapper.load_model('accelerator', 'Criterion')
 
 
 class CriterionFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/criterion_option_spec_factory.py
+++ b/accelerator/tests/factories/criterion_option_spec_factory.py
@@ -10,12 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.criterion_factory import (
     CriterionFactory
 )
-CriterionOptionSpec = swapper.load_model(AcceleratorConfig.name,
-                                         'CriterionOptionSpec')
+CriterionOptionSpec = swapper.load_model('accelerator', 'CriterionOptionSpec')
 
 
 class CriterionOptionSpecFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/currency_factory.py
+++ b/accelerator/tests/factories/currency_factory.py
@@ -8,9 +8,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Currency = swapper.load_model(AcceleratorConfig.name, 'Currency')
+Currency = swapper.load_model('accelerator', 'Currency')
 
 
 def _char_range(start, end):

--- a/accelerator/tests/factories/entrepreneur_profile_factory.py
+++ b/accelerator/tests/factories/entrepreneur_profile_factory.py
@@ -5,11 +5,9 @@ from __future__ import unicode_literals
 
 import swapper
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.core_profile_factory import CoreProfileFactory
 
-EntrepreneurProfile = swapper.load_model(AcceleratorConfig.name,
-                                         'EntrepreneurProfile')
+EntrepreneurProfile = swapper.load_model('accelerator', 'EntrepreneurProfile')
 
 
 class EntrepreneurProfileFactory(CoreProfileFactory):

--- a/accelerator/tests/factories/expert_category_factory.py
+++ b/accelerator/tests/factories/expert_category_factory.py
@@ -6,15 +6,13 @@ import swapper
 from factory import Iterator
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import VALID_EXPERT_CATEGORIES
 
 # The import of VALID_EXPERT_CATEGORIES is indicative of a deeper problem with
 # how ExpertCategorys are currently used.  See AC-5022 for the underlying
 # issue and a discussion of possible better long term solutions.
 
-ExpertCategory = swapper.load_model(AcceleratorConfig.name, 'ExpertCategory')
+ExpertCategory = swapper.load_model('accelerator', 'ExpertCategory')
 
 
 class ExpertCategoryFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/expert_interest_factory.py
+++ b/accelerator/tests/factories/expert_interest_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import (
     ExpertFactory,
 )
@@ -21,7 +20,7 @@ from accelerator.tests.factories.program_family_factory import (
     ProgramFamilyFactory
 )
 
-ExpertInterest = swapper.load_model(AcceleratorConfig.name, 'ExpertInterest')
+ExpertInterest = swapper.load_model('accelerator, 'ExpertInterest')
 
 
 class ExpertInterestFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/expert_interest_factory.py
+++ b/accelerator/tests/factories/expert_interest_factory.py
@@ -20,7 +20,7 @@ from accelerator.tests.factories.program_family_factory import (
     ProgramFamilyFactory
 )
 
-ExpertInterest = swapper.load_model('accelerator, 'ExpertInterest')
+ExpertInterest = swapper.load_model('accelerator', 'ExpertInterest')
 
 
 class ExpertInterestFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/expert_interest_type_factory.py
+++ b/accelerator/tests/factories/expert_interest_type_factory.py
@@ -7,10 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-ExpertInterestType = swapper.load_model(AcceleratorConfig.name,
-                                        'ExpertInterestType')
+ExpertInterestType = swapper.load_model('accelerator', 'ExpertInterestType')
 
 
 class ExpertInterestTypeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/expert_profile_factory.py
+++ b/accelerator/tests/factories/expert_profile_factory.py
@@ -10,7 +10,6 @@ from factory import (
     post_generation,
 )
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.core_profile_factory import CoreProfileFactory
 from accelerator.tests.factories.expert_category_factory import (
     ExpertCategoryFactory
@@ -20,7 +19,7 @@ from accelerator.tests.factories.program_family_factory import (
     ProgramFamilyFactory
 )
 
-ExpertProfile = swapper.load_model(AcceleratorConfig.name, 'ExpertProfile')
+ExpertProfile = swapper.load_model('accelerator', 'ExpertProfile')
 
 
 class ExpertProfileFactory(CoreProfileFactory):

--- a/accelerator/tests/factories/functional_expertise_factory.py
+++ b/accelerator/tests/factories/functional_expertise_factory.py
@@ -10,9 +10,7 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-FunctionalExpertise = swapper.load_model(AcceleratorConfig.name,
+FunctionalExpertise = swapper.load_model('accelerator',
                                          'FunctionalExpertise')
 
 

--- a/accelerator/tests/factories/industry_factory.py
+++ b/accelerator/tests/factories/industry_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Industry = swapper.load_model(AcceleratorConfig.name, 'Industry')
+Industry = swapper.load_model('accelerator', 'Industry')
 
 
 class IndustryFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/interest_category_factory.py
+++ b/accelerator/tests/factories/interest_category_factory.py
@@ -11,11 +11,9 @@ from factory import (
 from factory.django import DjangoModelFactory
 
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 
-InterestCategory = swapper.load_model(AcceleratorConfig.name,
-                                      'InterestCategory')
+InterestCategory = swapper.load_model('accelerator', 'InterestCategory')
 
 
 class InterestCategoryFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/job_posting_factory.py
+++ b/accelerator/tests/factories/job_posting_factory.py
@@ -17,10 +17,9 @@ from factory.django import DjangoModelFactory
 
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-JobPosting = swapper.load_model(AcceleratorConfig.name, 'JobPosting')
+JobPosting = swapper.load_model('accelerator', 'JobPosting')
 
 
 class JobPostingFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/judge_application_feedback_factory.py
+++ b/accelerator/tests/factories/judge_application_feedback_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     JUDGING_FEEDBACK_STATUS_INCOMPLETE,
     JUDGING_STATUS_NO_CONFLICT,
@@ -20,7 +19,7 @@ from accelerator.tests.factories.expert_factory import ExpertFactory
 from accelerator.tests.factories.judging_form_factory import JudgingFormFactory
 from accelerator.tests.factories.panel_factory import PanelFactory
 
-JudgeApplicationFeedback = swapper.load_model(AcceleratorConfig.name,
+JudgeApplicationFeedback = swapper.load_model('accelerator',
                                               'JudgeApplicationFeedback')
 
 

--- a/accelerator/tests/factories/judge_availability_factory.py
+++ b/accelerator/tests/factories/judge_availability_factory.py
@@ -7,7 +7,6 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judge_round_commitment_factory import (
     JudgeRoundCommitmentFactory,
 )
@@ -17,8 +16,7 @@ from accelerator.tests.factories.panel_location_factory import (
 from accelerator.tests.factories.panel_time_factory import PanelTimeFactory
 from accelerator.tests.factories.panel_type_factory import PanelTypeFactory
 
-JudgeAvailability = swapper.load_model(AcceleratorConfig.name,
-                                       'JudgeAvailability')
+JudgeAvailability = swapper.load_model('accelerator', 'JudgeAvailability')
 
 
 class JudgeAvailabilityFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/judge_feedback_component_factory.py
+++ b/accelerator/tests/factories/judge_feedback_component_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judge_application_feedback_factory import (
     JudgeApplicationFeedbackFactory,
 )
@@ -18,7 +17,7 @@ from accelerator.tests.factories.judging_form_element_factory import (
     JudgingFormElementFactory
 )
 
-JudgeFeedbackComponent = swapper.load_model(AcceleratorConfig.name,
+JudgeFeedbackComponent = swapper.load_model('accelerator',
                                             'JudgeFeedbackComponent')
 
 

--- a/accelerator/tests/factories/judge_panel_assignment_factory.py
+++ b/accelerator/tests/factories/judge_panel_assignment_factory.py
@@ -10,13 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import COMPLETE_PANEL_ASSIGNMENT_STATUS
 from accelerator.tests.factories.expert_factory import ExpertFactory
 from accelerator.tests.factories.panel_factory import PanelFactory
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
-JudgePanelAssignment = swapper.load_model(AcceleratorConfig.name,
+JudgePanelAssignment = swapper.load_model('accelerator',
                                           'JudgePanelAssignment')
 
 

--- a/accelerator/tests/factories/judge_round_commitment_factory.py
+++ b/accelerator/tests/factories/judge_round_commitment_factory.py
@@ -9,13 +9,12 @@ from factory import SubFactory
 from factory.django import DjangoModelFactory
 
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.expert_factory import ExpertFactory
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
 
-JudgeRoundCommitment = swapper.load_model(AcceleratorConfig.name,
+JudgeRoundCommitment = swapper.load_model('accelerator',
                                           'JudgeRoundCommitment')
 
 

--- a/accelerator/tests/factories/judging_form_element_factory.py
+++ b/accelerator/tests/factories/judging_form_element_factory.py
@@ -10,13 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_question_factory import (
     ApplicationQuestionFactory
 )
 from accelerator.tests.factories.judging_form_factory import JudgingFormFactory
 
-JudgingFormElement = swapper.load_model(AcceleratorConfig.name,
+JudgingFormElement = swapper.load_model('accelerator',
                                         'JudgingFormElement')
 
 

--- a/accelerator/tests/factories/judging_form_factory.py
+++ b/accelerator/tests/factories/judging_form_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-JudgingForm = swapper.load_model(AcceleratorConfig.name, 'JudgingForm')
+JudgingForm = swapper.load_model('accelerator', 'JudgingForm')
 
 
 class JudgingFormFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/judging_round_factory.py
+++ b/accelerator/tests/factories/judging_round_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     CAPTURE_AVAILABILITY_DISABLED,
     FEEDBACK_DISPLAY_DISABLED,
@@ -34,7 +33,7 @@ from accelerator_abstract.models.base_judging_round import (
     SCENARIO_DETECTION,
 )
 
-JudgingRound = swapper.load_model(AcceleratorConfig.name, 'JudgingRound')
+JudgingRound = swapper.load_model('accelerator', 'JudgingRound')
 
 
 class JudgingRoundFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/legal_check_factory.py
+++ b/accelerator/tests/factories/legal_check_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-LegalCheck = swapper.load_model(AcceleratorConfig.name, 'LegalCheck')
+LegalCheck = swapper.load_model('accelerator', 'LegalCheck')
 
 
 class LegalCheckFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/location_factory.py
+++ b/accelerator/tests/factories/location_factory.py
@@ -5,9 +5,7 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Location = swapper.load_model(AcceleratorConfig.name, 'Location')
+Location = swapper.load_model('accelerator', 'Location')
 
 
 class LocationFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/member_profile_factory.py
+++ b/accelerator/tests/factories/member_profile_factory.py
@@ -5,10 +5,9 @@ from __future__ import unicode_literals
 
 import swapper
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.core_profile_factory import CoreProfileFactory
 
-MemberProfile = swapper.load_model(AcceleratorConfig.name, 'MemberProfile')
+MemberProfile = swapper.load_model('accelerator', 'MemberProfile')
 
 
 class MemberProfileFactory(CoreProfileFactory):

--- a/accelerator/tests/factories/mentor_program_office_hour_factory.py
+++ b/accelerator/tests/factories/mentor_program_office_hour_factory.py
@@ -18,7 +18,6 @@ from factory.django import DjangoModelFactory
 
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import (
     EntrepreneurFactory,
     ExpertFactory,
@@ -27,7 +26,7 @@ from accelerator.tests.factories.location_factory import LocationFactory
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-MentorProgramOfficeHour = swapper.load_model(AcceleratorConfig.name,
+MentorProgramOfficeHour = swapper.load_model('accelerator',
                                              'MentorProgramOfficeHour')
 
 

--- a/accelerator/tests/factories/mentoring_specialties_factory.py
+++ b/accelerator/tests/factories/mentoring_specialties_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-MentoringSpecialties = swapper.load_model(AcceleratorConfig.name,
+MentoringSpecialties = swapper.load_model('accelerator',
                                           'MentoringSpecialties')
 
 

--- a/accelerator/tests/factories/model_change_factory.py
+++ b/accelerator/tests/factories/model_change_factory.py
@@ -7,11 +7,9 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import MIGRATION_STATUS_OLD
 
-ModelChange = swapper.load_model(AcceleratorConfig.name, 'ModelChange')
+ModelChange = swapper.load_model('accelerator', 'ModelChange')
 
 
 class ModelChangeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/named_group_factory.py
+++ b/accelerator/tests/factories/named_group_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-NamedGroup = swapper.load_model(AcceleratorConfig.name, 'NamedGroup')
+NamedGroup = swapper.load_model('accelerator', 'NamedGroup')
 
 
 class NamedGroupFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/nav_tree_factory.py
+++ b/accelerator/tests/factories/nav_tree_factory.py
@@ -7,10 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-NavTree = swapper.load_model(
-    AcceleratorConfig.name, 'NavTree')
+NavTree = swapper.load_model('accelerator', 'NavTree')
 
 
 class NavTreeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/nav_tree_item_factory.py
+++ b/accelerator/tests/factories/nav_tree_item_factory.py
@@ -10,13 +10,9 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-from accelerator.tests.factories import (
-    NavTreeFactory,
-)
+from accelerator.tests.factories import NavTreeFactory
 
-NavTreeItem = swapper.load_model(
-    AcceleratorConfig.name, 'NavTreeItem')
+NavTreeItem = swapper.load_model('accelerator', 'NavTreeItem')
 
 
 class NavTreeItemFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/newsletter_factory.py
+++ b/accelerator/tests/factories/newsletter_factory.py
@@ -10,13 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
 from accelerator.tests.factories.program_factory import ProgramFactory
 
-Newsletter = swapper.load_model(AcceleratorConfig.name, 'Newsletter')
+Newsletter = swapper.load_model('accelerator', 'Newsletter')
 
 
 class NewsletterFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/newsletter_receipt_factory.py
+++ b/accelerator/tests/factories/newsletter_receipt_factory.py
@@ -8,14 +8,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.entrepreneur_factory import (
     EntrepreneurFactory
 )
 from accelerator.tests.factories.newsletter_factory import NewsletterFactory
 
-NewsletterReceipt = swapper.load_model(AcceleratorConfig.name,
-                                       'NewsletterReceipt')
+NewsletterReceipt = swapper.load_model('accelerator', 'NewsletterReceipt')
 
 
 class NewsletterReceiptFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/node_published_for_factory.py
+++ b/accelerator/tests/factories/node_published_for_factory.py
@@ -7,12 +7,10 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_role_factory import ProgramRoleFactory
 from accelerator.tests.factories.url_node_factory import UrlNodeFactory
 
-NodePublishedFor = swapper.load_model(AcceleratorConfig.name,
-                                      'NodePublishedFor')
+NodePublishedFor = swapper.load_model('accelerator', 'NodePublishedFor')
 
 
 class NodePublishedForFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/observer_factory.py
+++ b/accelerator/tests/factories/observer_factory.py
@@ -10,9 +10,7 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Observer = swapper.load_model(AcceleratorConfig.name, 'Observer')
+Observer = swapper.load_model('accelerator', 'Observer')
 
 
 class ObserverFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/organization_factory.py
+++ b/accelerator/tests/factories/organization_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Organization = swapper.load_model(AcceleratorConfig.name, 'Organization')
+Organization = swapper.load_model('accelerator', 'Organization')
 
 
 class OrganizationFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/panel_factory.py
+++ b/accelerator/tests/factories/panel_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import PREVIEW_PANEL_STATUS
 from accelerator.tests.factories.panel_location_factory import (
     PanelLocationFactory
@@ -18,7 +17,7 @@ from accelerator.tests.factories.panel_location_factory import (
 from accelerator.tests.factories.panel_time_factory import PanelTimeFactory
 from accelerator.tests.factories.panel_type_factory import PanelTypeFactory
 
-Panel = swapper.load_model(AcceleratorConfig.name, 'Panel')
+Panel = swapper.load_model('accelerator', 'Panel')
 
 
 class PanelFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/panel_location_factory.py
+++ b/accelerator/tests/factories/panel_location_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
 
-PanelLocation = swapper.load_model(AcceleratorConfig.name, 'PanelLocation')
+PanelLocation = swapper.load_model('accelerator', 'PanelLocation')
 
 
 class PanelLocationFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/panel_time_factory.py
+++ b/accelerator/tests/factories/panel_time_factory.py
@@ -9,14 +9,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
 from accelerator.tests.utils import months_from_now
 
-PanelTime = swapper.load_model(AcceleratorConfig.name, 'PanelTime')
+PanelTime = swapper.load_model('accelerator', 'PanelTime')
 
 
 class PanelTimeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/panel_type_factory.py
+++ b/accelerator/tests/factories/panel_type_factory.py
@@ -11,12 +11,11 @@ from factory import (
 
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.judging_round_factory import (
     JudgingRoundFactory
 )
 
-PanelType = swapper.load_model(AcceleratorConfig.name, 'PanelType')
+PanelType = swapper.load_model('accelerator', 'PanelType')
 
 
 class PanelTypeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/partner_factory.py
+++ b/accelerator/tests/factories/partner_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.organization_factory import (
     OrganizationFactory
 )
 
-Partner = swapper.load_model(AcceleratorConfig.name, 'Partner')
+Partner = swapper.load_model('accelerator', 'Partner')
 
 
 class PartnerFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/partner_team_member_factory.py
+++ b/accelerator/tests/factories/partner_team_member_factory.py
@@ -7,12 +7,10 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from .entrepreneur_factory import EntrepreneurFactory
 from .partner_factory import PartnerFactory
 
-PartnerTeamMember = swapper.load_model(AcceleratorConfig.name,
-                                       'PartnerTeamMember')
+PartnerTeamMember = swapper.load_model('accelerator', 'PartnerTeamMember')
 
 
 class PartnerTeamMemberFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/paypal_payment_factory.py
+++ b/accelerator/tests/factories/paypal_payment_factory.py
@@ -10,11 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from .program_cycle_factory import ProgramCycleFactory
 from .startup_factory import StartupFactory
 
-PayPalPayment = swapper.load_model(AcceleratorConfig.name, 'PayPalPayment')
+PayPalPayment = swapper.load_model('accelerator', 'PayPalPayment')
 
 
 class PayPalPaymentFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_cycle_factory.py
+++ b/accelerator/tests/factories/program_cycle_factory.py
@@ -10,13 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_type_factory import (
     ApplicationTypeFactory
 )
 from accelerator.tests.utils import months_from_now
 
-ProgramCycle = swapper.load_model(AcceleratorConfig.name, 'ProgramCycle')
+ProgramCycle = swapper.load_model('accelerator', 'ProgramCycle')
 
 
 class ProgramCycleFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_factory.py
+++ b/accelerator/tests/factories/program_factory.py
@@ -12,7 +12,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import ACTIVE_PROGRAM_STATUS
 from accelerator.tests.factories.program_cycle_factory import (
     ProgramCycleFactory
@@ -22,7 +21,7 @@ from accelerator.tests.factories.program_family_factory import (
 )
 from accelerator.tests.utils import months_from_now
 
-Program = swapper.load_model(AcceleratorConfig.name, 'Program')
+Program = swapper.load_model('accelerator', 'Program')
 
 
 class ProgramFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_family_factory.py
+++ b/accelerator/tests/factories/program_family_factory.py
@@ -7,10 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
-
-ProgramFamily = swapper.load_model(AcceleratorConfig.name, 'ProgramFamily')
+ProgramFamily = swapper.load_model('accelerator', 'ProgramFamily')
 
 
 class ProgramFamilyFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_family_location_factory.py
+++ b/accelerator/tests/factories/program_family_location_factory.py
@@ -4,13 +4,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import (
     ProgramFamilyFactory,
 )
 from accelerator.tests.factories.location_factory import LocationFactory
 
-ProgramFamilyLocation = swapper.load_model(AcceleratorConfig.name,
+ProgramFamilyLocation = swapper.load_model('accelerator',
                                            'ProgramFamilyLocation')
 
 

--- a/accelerator/tests/factories/program_interest_factory.py
+++ b/accelerator/tests/factories/program_interest_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.startup_cycle_interest_factory import (
     StartupCycleInterestFactory
 )
 
-ProgramInterest = swapper.load_model(AcceleratorConfig.name, 'ProgramInterest')
+ProgramInterest = swapper.load_model('accelerator', 'ProgramInterest')
 
 
 class ProgramInterestFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_override_factory.py
+++ b/accelerator/tests/factories/program_override_factory.py
@@ -14,13 +14,12 @@ from factory.django import DjangoModelFactory
 
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_cycle_factory import (
     ProgramCycleFactory
 )
 from accelerator.tests.factories.program_factory import ProgramFactory
 
-ProgramOverride = swapper.load_model(AcceleratorConfig.name, 'ProgramOverride')
+ProgramOverride = swapper.load_model('accelerator', 'ProgramOverride')
 
 
 class ProgramOverrideFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_partner_factory.py
+++ b/accelerator/tests/factories/program_partner_factory.py
@@ -10,14 +10,13 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.partner_factory import PartnerFactory
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.program_partner_type_factory import (
     ProgramPartnerTypeFactory
 )
 
-ProgramPartner = swapper.load_model(AcceleratorConfig.name, 'ProgramPartner')
+ProgramPartner = swapper.load_model('accelerator', 'ProgramPartner')
 
 
 class ProgramPartnerFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_partner_type_factory.py
+++ b/accelerator/tests/factories/program_partner_type_factory.py
@@ -10,11 +10,9 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import ProgramFactory
 
-ProgramPartnerType = swapper.load_model(AcceleratorConfig.name,
-                                        'ProgramPartnerType')
+ProgramPartnerType = swapper.load_model('accelerator', 'ProgramPartnerType')
 
 
 class ProgramPartnerTypeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_role_factory.py
+++ b/accelerator/tests/factories/program_role_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.user_label_factory import UserLabelFactory
 from accelerator.tests.factories.user_role_factory import UserRoleFactory
 
-ProgramRole = swapper.load_model(AcceleratorConfig.name, 'ProgramRole')
+ProgramRole = swapper.load_model('accelerator', 'ProgramRole')
 
 
 class ProgramRoleFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_role_grant_factory.py
+++ b/accelerator/tests/factories/program_role_grant_factory.py
@@ -7,12 +7,10 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.member_factory import MemberFactory
 from accelerator.tests.factories.program_role_factory import ProgramRoleFactory
 
-ProgramRoleGrant = swapper.load_model(AcceleratorConfig.name,
-                                      'ProgramRoleGrant')
+ProgramRoleGrant = swapper.load_model('accelerator', 'ProgramRoleGrant')
 
 
 class ProgramRoleGrantFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/program_startup_attribute_factory.py
+++ b/accelerator/tests/factories/program_startup_attribute_factory.py
@@ -10,10 +10,9 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 
-ProgramStartupAttribute = swapper.load_model(AcceleratorConfig.name,
+ProgramStartupAttribute = swapper.load_model('accelerator',
                                              'ProgramStartupAttribute')
 
 

--- a/accelerator/tests/factories/program_startup_status_factory.py
+++ b/accelerator/tests/factories/program_startup_status_factory.py
@@ -10,12 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.startup_role_factory import StartupRoleFactory
 
-ProgramStartupStatus = swapper.load_model(AcceleratorConfig.name,
+ProgramStartupStatus = swapper.load_model('accelerator',
                                           'ProgramStartupStatus')
 
 

--- a/accelerator/tests/factories/question_factory.py
+++ b/accelerator/tests/factories/question_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     CHOICE_LAYOUT_HORIZONTAL,
     QUESTION_TYPE_MULTILINE,
 )
 
-Question = swapper.load_model(AcceleratorConfig.name, 'Question')
+Question = swapper.load_model('accelerator', 'Question')
 
 
 class QuestionFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/recommendation_tag_factory.py
+++ b/accelerator/tests/factories/recommendation_tag_factory.py
@@ -7,10 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-RecommendationTag = swapper.load_model(AcceleratorConfig.name,
-                                       'RecommendationTag')
+RecommendationTag = swapper.load_model('accelerator', 'RecommendationTag')
 
 
 class RecommendationTagFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/reference_factory.py
+++ b/accelerator/tests/factories/reference_factory.py
@@ -15,11 +15,10 @@ from factory.django import DjangoModelFactory
 
 from pytz import utc
 
-from accelerator.apps import AcceleratorConfig
 from .application_factory import ApplicationFactory
 from .entrepreneur_factory import EntrepreneurFactory
 
-Reference = swapper.load_model(AcceleratorConfig.name, 'Reference')
+Reference = swapper.load_model('accelerator', 'Reference')
 
 
 class ReferenceFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/refund_code_factory.py
+++ b/accelerator/tests/factories/refund_code_factory.py
@@ -11,10 +11,9 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from .partner_factory import PartnerFactory
 
-RefundCode = swapper.load_model(AcceleratorConfig.name, 'RefundCode')
+RefundCode = swapper.load_model('accelerator', 'RefundCode')
 
 
 class RefundCodeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/refund_code_redemption_factory.py
+++ b/accelerator/tests/factories/refund_code_redemption_factory.py
@@ -10,12 +10,11 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from .program_cycle_factory import ProgramCycleFactory
 from .refund_code_factory import RefundCodeFactory
 from .startup_factory import StartupFactory
 
-RefundCodeRedemption = swapper.load_model(AcceleratorConfig.name,
+RefundCodeRedemption = swapper.load_model('accelerator',
                                           'RefundCodeRedemption')
 
 

--- a/accelerator/tests/factories/scenario_application_factory.py
+++ b/accelerator/tests/factories/scenario_application_factory.py
@@ -7,11 +7,10 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.application_factory import ApplicationFactory
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
-ScenarioApplication = swapper.load_model(AcceleratorConfig.name,
+ScenarioApplication = swapper.load_model('accelerator',
                                          'ScenarioApplication')
 
 

--- a/accelerator/tests/factories/scenario_factory.py
+++ b/accelerator/tests/factories/scenario_factory.py
@@ -11,11 +11,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import DEFAULT_PANEL_SIZE
 from .judging_round_factory import JudgingRoundFactory
 
-Scenario = swapper.load_model(AcceleratorConfig.name, 'Scenario')
+Scenario = swapper.load_model('accelerator', 'Scenario')
 
 
 class ScenarioFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/scenario_judge_factory.py
+++ b/accelerator/tests/factories/scenario_judge_factory.py
@@ -7,11 +7,10 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.expert_factory import ExpertFactory
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
-ScenarioJudge = swapper.load_model(AcceleratorConfig.name, 'ScenarioJudge')
+ScenarioJudge = swapper.load_model('accelerator', 'ScenarioJudge')
 
 
 class ScenarioJudgeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/scenario_preference_factory.py
+++ b/accelerator/tests/factories/scenario_preference_factory.py
@@ -10,7 +10,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     JUDGE_ENTITY,
     JUDGE_IS_FEMALE,
@@ -18,8 +17,7 @@ from accelerator.models import (
 )
 from accelerator.tests.factories.scenario_factory import ScenarioFactory
 
-ScenarioPreference = swapper.load_model(AcceleratorConfig.name,
-                                        'ScenarioPreference')
+ScenarioPreference = swapper.load_model('accelerator', 'ScenarioPreference')
 
 
 class ScenarioPreferenceFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/section_factory.py
+++ b/accelerator/tests/factories/section_factory.py
@@ -10,11 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import NewsletterFactory
 from accelerator_abstract.models.base_section import INCLUDE_FOR_CHOICES
 
-Section = swapper.load_model(AcceleratorConfig.name, 'Section')
+Section = swapper.load_model('accelerator', 'Section')
 
 
 class SectionFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/site_factory.py
+++ b/accelerator/tests/factories/site_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-Site = swapper.load_model(AcceleratorConfig.name, 'Site')
+Site = swapper.load_model('accelerator', 'Site')
 
 
 class SiteFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/site_program_authorization_factory.py
+++ b/accelerator/tests/factories/site_program_authorization_factory.py
@@ -10,11 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from .program_factory import ProgramFactory
 from .site_factory import SiteFactory
 
-SiteProgramAuthorization = swapper.load_model(AcceleratorConfig.name,
+SiteProgramAuthorization = swapper.load_model('accelerator',
                                               'SiteProgramAuthorization')
 
 

--- a/accelerator/tests/factories/startup_attribute_factory.py
+++ b/accelerator/tests/factories/startup_attribute_factory.py
@@ -10,15 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_startup_attribute_factory import (
     ProgramStartupAttributeFactory,
 )
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupAttribute = swapper.load_model(AcceleratorConfig.name,
-                                      'StartupAttribute')
+StartupAttribute = swapper.load_model('accelerator', 'StartupAttribute')
 
 
 class StartupAttributeFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/startup_cycle_interest_factory.py
+++ b/accelerator/tests/factories/startup_cycle_interest_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_cycle_factory import (
     ProgramCycleFactory
 )
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupCycleInterest = swapper.load_model(AcceleratorConfig.name,
+StartupCycleInterest = swapper.load_model('accelerator',
                                           'StartupCycleInterest')
 
 

--- a/accelerator/tests/factories/startup_factory.py
+++ b/accelerator/tests/factories/startup_factory.py
@@ -12,7 +12,6 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.models import (
     DEFAULT_PROFILE_BACKGROUND_COLOR,
     DEFAULT_PROFILE_TEXT_COLOR,
@@ -28,7 +27,7 @@ from accelerator.tests.factories.organization_factory import (
 )
 from accelerator.tests.utils import days_from_now
 
-Startup = swapper.load_model(AcceleratorConfig.name, 'Startup')
+Startup = swapper.load_model('accelerator', 'Startup')
 
 COMMUNITY_VALUES = [val[0] for val in STARTUP_COMMUNITIES]
 

--- a/accelerator/tests/factories/startup_label_factory.py
+++ b/accelerator/tests/factories/startup_label_factory.py
@@ -10,10 +10,7 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
-
-StartupLabel = swapper.load_model(AcceleratorConfig.name, 'StartupLabel')
+StartupLabel = swapper.load_model('accelerator', 'StartupLabel')
 
 
 class StartupLabelFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/startup_mentor_relationship_factory.py
+++ b/accelerator/tests/factories/startup_mentor_relationship_factory.py
@@ -7,7 +7,6 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.expert_factory import ExpertFactory
 from accelerator.tests.factories.startup_mentor_tracking_record_factory \
     import StartupMentorTrackingRecordFactory
@@ -15,7 +14,7 @@ from accelerator_abstract.models.base_startup_mentor_relationship import (
     CONFIRMED_RELATIONSHIP,
 )
 
-StartupMentorRelationship = swapper.load_model(AcceleratorConfig.name,
+StartupMentorRelationship = swapper.load_model('accelerator',
                                                'StartupMentorRelationship')
 
 

--- a/accelerator/tests/factories/startup_mentor_tracking_record_factory.py
+++ b/accelerator/tests/factories/startup_mentor_tracking_record_factory.py
@@ -10,11 +10,10 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupMentorTrackingRecord = swapper.load_model(AcceleratorConfig.name,
+StartupMentorTrackingRecord = swapper.load_model('accelerator',
                                                  'StartupMentorTrackingRecord')
 
 

--- a/accelerator/tests/factories/startup_override_grant_factory.py
+++ b/accelerator/tests/factories/startup_override_grant_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import (
     ProgramOverrideFactory,
     StartupFactory,
 )
 
-StartupOverrideGrant = swapper.load_model(AcceleratorConfig.name,
+StartupOverrideGrant = swapper.load_model('accelerator',
                                           'StartupOverrideGrant')
 
 

--- a/accelerator/tests/factories/startup_program_interest_factory.py
+++ b/accelerator/tests/factories/startup_program_interest_factory.py
@@ -10,14 +10,13 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_factory import ProgramFactory
 from accelerator.tests.factories.startup_cycle_interest_factory import (
     StartupCycleInterestFactory,
 )
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupProgramInterest = swapper.load_model(AcceleratorConfig.name,
+StartupProgramInterest = swapper.load_model('accelerator',
                                             'StartupProgramInterest')
 
 

--- a/accelerator/tests/factories/startup_role_factory.py
+++ b/accelerator/tests/factories/startup_role_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-StartupRole = swapper.load_model(AcceleratorConfig.name, 'StartupRole')
+StartupRole = swapper.load_model('accelerator', 'StartupRole')
 
 
 class StartupRoleFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/startup_status_factory.py
+++ b/accelerator/tests/factories/startup_status_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.program_startup_status_factory import (
     ProgramStartupStatusFactory,
 )
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupStatus = swapper.load_model(AcceleratorConfig.name, 'StartupStatus')
+StartupStatus = swapper.load_model('accelerator', 'StartupStatus')
 
 
 class StartupStatusFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/startup_team_member_factory.py
+++ b/accelerator/tests/factories/startup_team_member_factory.py
@@ -10,16 +10,12 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.entrepreneur_factory import (
     EntrepreneurFactory
 )
 from accelerator.tests.factories.startup_factory import StartupFactory
 
-StartupTeamMember = swapper.load_model(
-    AcceleratorConfig.name,
-    'StartupTeamMember')
+StartupTeamMember = swapper.load_model('accelerator', 'StartupTeamMember')
 
 
 class StartupTeamMemberFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/subnav_association_factory.py
+++ b/accelerator/tests/factories/subnav_association_factory.py
@@ -7,7 +7,6 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories import (
     NavTreeFactory,
     NavTreeItemFactory,
@@ -15,7 +14,7 @@ from accelerator.tests.factories import (
 )
 
 NodeSubNavAssociation = swapper.load_model(
-    AcceleratorConfig.name, 'NodeSubNavAssociation')
+    'accelerator', 'NodeSubNavAssociation')
 
 
 class NodeSubNavAssociationFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/user_label_factory.py
+++ b/accelerator/tests/factories/user_label_factory.py
@@ -10,9 +10,7 @@ from factory import (
 )
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-UserLabel = swapper.load_model(AcceleratorConfig.name, 'UserLabel')
+UserLabel = swapper.load_model('accelerator', 'UserLabel')
 
 
 class UserLabelFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/user_legal_check_factory.py
+++ b/accelerator/tests/factories/user_legal_check_factory.py
@@ -7,13 +7,12 @@ import swapper
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.tests.factories.legal_check_factory import (
     LegalCheckFactory
 )
 from simpleuser.tests.factories.user_factory import UserFactory
 
-UserLegalCheck = swapper.load_model(AcceleratorConfig.name, 'UserLegalCheck')
+UserLegalCheck = swapper.load_model('accelerator', 'UserLegalCheck')
 
 
 class UserLegalCheckFactory(DjangoModelFactory):

--- a/accelerator/tests/factories/user_role_factory.py
+++ b/accelerator/tests/factories/user_role_factory.py
@@ -7,9 +7,7 @@ import swapper
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
-from accelerator.apps import AcceleratorConfig
-
-UserRole = swapper.load_model(AcceleratorConfig.name, 'UserRole')
+UserRole = swapper.load_model('accelerator', 'UserRole')
 
 
 class UserRoleFactory(DjangoModelFactory):

--- a/accelerator/tests/utils.py
+++ b/accelerator/tests/utils.py
@@ -10,7 +10,6 @@ from datetime import (
 
 from django.urls import reverse
 from pytz import utc
-from accelerator.apps import AcceleratorConfig
 import logging
 
 
@@ -25,7 +24,7 @@ def get_app_name():
         return MCAppConfig.name
     except ImportError as error:
         logger.warning(error)
-        return AcceleratorConfig.name
+        return 'accelerator'
 
 
 def login_as_user(test, user):

--- a/accelerator_abstract/apps.py
+++ b/accelerator_abstract/apps.py
@@ -4,12 +4,10 @@ import swapper
 from django.apps import AppConfig
 from django.contrib.auth import get_user_model
 
-from accelerator.apps import AcceleratorConfig
-
 
 def add_get_profile_to_user_class():
     User = get_user_model()
-    BaseProfile = swapper.load_model(AcceleratorConfig.name, 'BaseProfile')
+    BaseProfile = swapper.load_model('accelerator', 'BaseProfile')
     User.add_to_class('get_profile',
                       lambda user: BaseProfile.objects.get(
                           email=user.email))

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -11,9 +11,7 @@ from django.db import models
 from django.db.models import Q
 from sorl.thumbnail import ImageField
 
-from accelerator.apps import AcceleratorConfig
 from accelerator.utils import bullet_train_has_feature
-
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 from accelerator_abstract.models.base_user_role import (
     BaseUserRole,
@@ -188,13 +186,13 @@ class BaseCoreProfile(AcceleratorModel):
 
     def is_partner(self):
         PartnerTeamMember = swapper.load_model(
-            AcceleratorConfig.name, 'PartnerTeamMember')
+            'accelerator', 'PartnerTeamMember')
         return PartnerTeamMember.objects.filter(
             team_member=self.user).exists()
 
     def is_partner_admin(self):
         PartnerTeamMember = swapper.load_model(
-            AcceleratorConfig.name, 'PartnerTeamMember')
+            'accelerator', 'PartnerTeamMember')
         return PartnerTeamMember.objects.filter(
             team_member=self.user,
             partner_administrator=True).exists()
@@ -219,7 +217,7 @@ class BaseCoreProfile(AcceleratorModel):
         JudgingRound = swapper.load_model(AcceleratorModel.Meta.app_label,
                                           "JudgingRound")
         UserRole = swapper.load_model(
-            AcceleratorConfig.name, 'UserRole')
+            'accelerator', 'UserRole')
         now = utc.localize(datetime.now())
         active_judging_round_labels = JudgingRound.objects.filter(
             end_date_time__gt=now,


### PR DESCRIPTION
## [AC-7856](https://masschallenge.atlassian.net/browse/AC-7856)

Review suggestions:
* Note that [Travis build](https://travis-ci.com/github/masschallenge/django-accelerator/builds/197436197) is green
* Note that [Travis build of same-named accelerate branch](https://travis-ci.com/github/masschallenge/accelerate/builds/197371041) (which has no changes, but causes this branch of DA to be used in the build) is green