### PR TITLE
[AC-8419] P0: Django 2.2  DateTime fields are incompatible with MySQL 5.5

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ tox
 mock
 factory-boy
 swapper
+mysqlclient

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,9 @@
 import os
 import sys
 import logging
+from django.db.backends.mysql.base import DatabaseWrapper
+
+DatabaseWrapper.data_types['DateTimeField'] = 'datetime'
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
     logging.disable(logging.WARNING)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = [
     "django-polymorphic",
     "django-sitetree",
     "bullet-train",
+    "mysqlclient",
 ]
 
 setup(


### PR DESCRIPTION
## [AC-8419](https://masschallenge.atlassian.net/browse/AC-8419)
**Changes introduced**
- Update MySQL data type mapper to use `datetime` instead of `datetime(6)`
**Testing**
- ssh into test3
- Confirm that you can run migrations without MySQL compatibility error: `django.db.utils.ProgrammingError: (1064, "You have an error in your SQL syntax;`
[Sibling PR](https://github.com/masschallenge/accelerate/pull/2833)