### PR TITLE
[AC-8484] Migration 0028 reintroduces swappable

### DIFF
--- a/accelerator/migrations/0028_add_gender_choices_object.py
+++ b/accelerator/migrations/0028_add_gender_choices_object.py
@@ -28,7 +28,6 @@ class Migration(migrations.Migration):
                 'db_table': 'accelerator_genderchoices',
                 'abstract': False,
                 'managed': True,
-                'swappable': 'ACCELERATOR_GENDERCHOICES_MODEL',
             },
         ),
     ]


### PR DESCRIPTION
### Changes introduced in: [AC-8484](https://masschallenge.atlassian.net/browse/AC-8484):
- Removes swappable option in migration 0028

### How to test
- Drop the database `make db-shell` and in the mysql console `drop database mc_dev;`
- Recreate the database `create database mc_dev;` and exit
- load the database `make load-db` , migration `0028` should be applied
- verify in the database has the changes expected, the table `accelerator_ genderchoices` exists in the database