### PR TITLE
[AC-8516] P2: Expert profile demographic fields are difficult to use 

### DIFF
--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -34,6 +34,11 @@ GENDER_OTHER_CHOICE = ('o', 'Other')
 GENDER_PREFER_NOT_TO_STATE_CHOICE = ('p', 'Prefer Not To State')
 GENDER_UNKNOWN_CHOICE = ('', 'Unknown')
 
+IDENTITY_HELP_TEXT_VALUE = (mark_safe(
+            'Select as many options as you feel best represent your identity. '
+            'Please press and hold Control (CTRL) on PCs or '
+            'Command (&#8984;) on Macs to select multiple options'))
+
 GENDER_CHOICES = (
     GENDER_FEMALE_CHOICE,
     GENDER_MALE_CHOICE,
@@ -63,10 +68,7 @@ class BaseCoreProfile(AcceleratorModel):
     gender_identity = models.ManyToManyField(
         swapper.get_model_name(
             AcceleratorModel.Meta.app_label, 'GenderChoices'),
-        help_text=(mark_safe(
-            'Select as many options as you feel best represent your identity. '
-            'Please press and hold Control (CTRL) on PCs or '
-            'Command (&#8984;) on Macs to select multiple options')),
+        help_text=IDENTITY_HELP_TEXT_VALUE,
         blank=True
     )
     gender_self_description = models.TextField(blank=True, default="")
@@ -136,10 +138,7 @@ class BaseCoreProfile(AcceleratorModel):
             AcceleratorModel.Meta.app_label, 'EthnoRacialIdentity'
         ),
         blank=True,
-        help_text=(mark_safe(
-            'Select as many options as you feel best represent your identity. '
-            'Please press and hold Control (CTRL) on PCs or '
-            'Command (&#8984;) on Macs to select multiple options')),
+        help_text=IDENTITY_HELP_TEXT_VALUE
     )
     authorization_to_share_ethno_racial_identity = models.BooleanField(
         default=False,

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -10,6 +10,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import Q
 from sorl.thumbnail import ImageField
+from django.utils.safestring import mark_safe
 
 from accelerator.utils import bullet_train_has_feature
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
@@ -62,6 +63,10 @@ class BaseCoreProfile(AcceleratorModel):
     gender_identity = models.ManyToManyField(
         swapper.get_model_name(
             AcceleratorModel.Meta.app_label, 'GenderChoices'),
+        help_text=(mark_safe(
+            'Select as many options as you feel best represent your identity. '
+            'Please press and hold Control (CTRL) on PCs or '
+            'Command (&#8984;) on Macs to select multiple options')),
         blank=True
     )
     gender_self_description = models.TextField(blank=True, default="")
@@ -131,6 +136,10 @@ class BaseCoreProfile(AcceleratorModel):
             AcceleratorModel.Meta.app_label, 'EthnoRacialIdentity'
         ),
         blank=True,
+        help_text=(mark_safe(
+            'Select as many options as you feel best represent your identity. '
+            'Please press and hold Control (CTRL) on PCs or '
+            'Command (&#8984;) on Macs to select multiple options')),
     )
     authorization_to_share_ethno_racial_identity = models.BooleanField(
         default=False,


### PR DESCRIPTION
Changes introduced in [AC-8516](https://masschallenge.atlassian.net/browse/AC-8516)

- P2: Expert profile demographic fields are difficult to use

How to test

- The multi-select fields for ethno-racial identity and gender identity are consistent with the mockup so seven options are visible at once; mockup: https://www.figma.com/file/8zEeyAcxQCFtNf1oQtuAsF/Demographic-Information?node-id=163%3A0
-
<img width="1067" alt="Screenshot 2021-02-08 at 20 50 09" src="https://user-images.githubusercontent.com/28547970/107273826-e14fdc00-6a4f-11eb-88a9-c246139e5477.png">
