### PR TITLE
[AC-8495] remove python_2_unicode_compatible

### DIFF
--- a/accelerator_abstract/models/accelerator_model.py
+++ b/accelerator_abstract/models/accelerator_model.py
@@ -3,14 +3,12 @@
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 CHOICE_OPTION_HELP_TEXT = (
     "Provide a list of options separated by a “|” (ie. Yes|No)"
 )
 
 
-@python_2_unicode_compatible
 class AcceleratorModel(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, null=True)
     updated_at = models.DateTimeField(auto_now=True, null=True)

--- a/accelerator_abstract/models/base_allocator.py
+++ b/accelerator_abstract/models/base_allocator.py
@@ -8,11 +8,9 @@ from django.db.models import (
     CASCADE,
     OneToOneField,
 )
-from django.utils.encoding import python_2_unicode_compatible
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseAllocator(AcceleratorModel):
     judging_round = OneToOneField(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_application.py
+++ b/accelerator_abstract/models/base_application.py
@@ -7,7 +7,6 @@ import logging
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -39,7 +38,6 @@ REFUND_STATUSES = ((NOT_ELIGIBLE_STATUS, "Not Eligible For Refund"),
                    (FAILED_STATUS, "Refund Failed"))
 
 
-@python_2_unicode_compatible
 class BaseApplication(AcceleratorModel):
     cycle = models.ForeignKey(swapper.get_model_name('accelerator',
                                                      'ProgramCycle'),

--- a/accelerator_abstract/models/base_application_answer.py
+++ b/accelerator_abstract/models/base_application_answer.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseApplicationAnswer(AcceleratorModel):
     application = models.ForeignKey(to=swapper.get_model_name(
         AcceleratorModel.Meta.app_label, "Application"),

--- a/accelerator_abstract/models/base_application_panel_assignment.py
+++ b/accelerator_abstract/models/base_application_panel_assignment.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseApplicationPanelAssignment(AcceleratorModel):
     application = models.ForeignKey(swapper.get_model_name(
         AcceleratorModel.Meta.app_label, "Application"),

--- a/accelerator_abstract/models/base_application_question.py
+++ b/accelerator_abstract/models/base_application_question.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import (
     AcceleratorModel,
@@ -22,7 +21,6 @@ TEXT_LIMIT_UNITS = ((CHARACTERS_UNIT_NAME.lower(), CHARACTERS_UNIT_NAME),
                     (WORDS_UNIT_NAME.lower(), WORDS_UNIT_NAME))
 
 
-@python_2_unicode_compatible
 class BaseApplicationQuestion(AcceleratorModel):
     application_type = models.ForeignKey(swapper.get_model_name(
         AcceleratorModel.Meta.app_label, "ApplicationType"),

--- a/accelerator_abstract/models/base_base_profile.py
+++ b/accelerator_abstract/models/base_base_profile.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -21,7 +20,6 @@ TWITTER_HANDLE_MAX_LENGTH = 16
 PHONE_MAX_LENGTH = 20
 
 
-@python_2_unicode_compatible
 class BaseBaseProfile(AcceleratorModel):
     """pivot class that returns an appropriate profile based on user_type
 

--- a/accelerator_abstract/models/base_clearance.py
+++ b/accelerator_abstract/models/base_clearance.py
@@ -7,7 +7,6 @@ import logging
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -86,7 +85,6 @@ def _level_rank(user, level, program_family=None):
     return level_rank
 
 
-@python_2_unicode_compatible
 class BaseClearance(AcceleratorModel):
     objects = ClearanceManager()
     user = models.ForeignKey(settings.AUTH_USER_MODEL,

--- a/accelerator_abstract/models/base_expert_interest.py
+++ b/accelerator_abstract/models/base_expert_interest.py
@@ -7,7 +7,6 @@ import swapper
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -23,7 +22,6 @@ def is_expert_validator(value):
         raise ValidationError("User must be an expert")
 
 
-@python_2_unicode_compatible
 class BaseExpertInterest(AcceleratorModel):
     """Relates a specific user, program family, and expert interest type
 

--- a/accelerator_abstract/models/base_fluent_sub_nav_association.py
+++ b/accelerator_abstract/models/base_fluent_sub_nav_association.py
@@ -5,13 +5,11 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from fluent_pages.models import UrlNode
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseNodeSubNavAssociation(AcceleratorModel):
     node = models.ForeignKey(UrlNode, on_delete=models.CASCADE)
     sub_nav = models.ForeignKey(swapper.get_model_name(

--- a/accelerator_abstract/models/base_functional_expertise.py
+++ b/accelerator_abstract/models/base_functional_expertise.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from mptt.models import (
     MPTTModel,
     TreeForeignKey,
@@ -13,7 +12,6 @@ from mptt.models import (
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseFunctionalExpertise(MPTTModel, AcceleratorModel):
     name = models.CharField(max_length=255)
     parent = TreeForeignKey('self',

--- a/accelerator_abstract/models/base_industry.py
+++ b/accelerator_abstract/models/base_industry.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from mptt.models import (
     MPTTModel,
     TreeForeignKey,
@@ -13,7 +12,6 @@ from mptt.models import (
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseIndustry(MPTTModel, AcceleratorModel):
     name = models.CharField(max_length=255)
     icon = models.CharField(max_length=50, blank=True)

--- a/accelerator_abstract/models/base_job_posting.py
+++ b/accelerator_abstract/models/base_job_posting.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -17,7 +16,6 @@ JOB_TYPE_VALUES = (('NONE', 'None'),
                    ('FULL_TIME_CONTRACT', 'A full-time contract position'))
 
 
-@python_2_unicode_compatible
 class BaseJobPosting(AcceleratorModel):
     startup = models.ForeignKey(swapper.get_model_name(
         "accelerator", "Startup"),

--- a/accelerator_abstract/models/base_judge_application_feedback.py
+++ b/accelerator_abstract/models/base_judge_application_feedback.py
@@ -8,7 +8,6 @@ import logging
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -33,7 +32,6 @@ JUDGING_STATUS_ENUM = (
     (JUDGING_STATUS_OTHER, 'Not Judged - Other (eg., no show)'),)
 
 
-@python_2_unicode_compatible
 class BaseJudgeApplicationFeedback(AcceleratorModel):
     application = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Application"),

--- a/accelerator_abstract/models/base_judge_feedback_component.py
+++ b/accelerator_abstract/models/base_judge_feedback_component.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -37,7 +36,6 @@ LINEAR_SCORES = {
 }
 
 
-@python_2_unicode_compatible
 class BaseJudgeFeedbackComponent(AcceleratorModel):
     judge_feedback = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_judge_panel_assignment.py
+++ b/accelerator_abstract/models/base_judge_panel_assignment.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -19,7 +18,6 @@ JUDGE_PANEL_ASSIGNMENT_STATUS_ENUM = (
 )
 
 
-@python_2_unicode_compatible
 class BaseJudgePanelAssignment(AcceleratorModel):
     judge = models.ForeignKey(settings.AUTH_USER_MODEL,
                               on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_judge_round_commitment.py
+++ b/accelerator_abstract/models/base_judge_round_commitment.py
@@ -8,7 +8,6 @@ import logging
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -18,7 +17,6 @@ NOT_AVAILABLE_MSG = ("You have indicated that you are not available for "
                      "this round.")
 
 
-@python_2_unicode_compatible
 class BaseJudgeRoundCommitment(AcceleratorModel):
     judge = models.ForeignKey(settings.AUTH_USER_MODEL,
                               on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_judging_form_element.py
+++ b/accelerator_abstract/models/base_judging_form_element.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import (
     AcceleratorModel,
@@ -77,7 +76,6 @@ FORM_ELEM_FEEDBACK_TO_STARTUP = "FEEDBACK_TO_STARTUP"
 FORM_ELEM_FEEDBACK_TO_MC = 'FEEDBACK_TO_MC'
 
 
-@python_2_unicode_compatible
 class BaseJudgingFormElement(AcceleratorModel):
     form_type = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "JudgingForm"),

--- a/accelerator_abstract/models/base_judging_round.py
+++ b/accelerator_abstract/models/base_judging_round.py
@@ -13,7 +13,6 @@ from django.db.models import (
     TextField,
     CASCADE,
 )
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 from accelerator_abstract.utils import validate_capacity_options
@@ -100,7 +99,6 @@ COLLISION_DETECTION_CHOICES = (
 )
 
 
-@python_2_unicode_compatible
 class BaseJudgingRound(AcceleratorModel):
     program = ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, 'Program'),

--- a/accelerator_abstract/models/base_legal_check.py
+++ b/accelerator_abstract/models/base_legal_check.py
@@ -6,12 +6,10 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseLegalCheck(AcceleratorModel):
     name = models.CharField(max_length=128,
                             default='',

--- a/accelerator_abstract/models/base_mentor_program_office_hour.py
+++ b/accelerator_abstract/models/base_mentor_program_office_hour.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -16,7 +15,6 @@ HOUR_NOT_SPECIFIED_MESSAGE = "Office hour has not been specified"
 HOUR_OWNED_BY_ANOTHER_MESSAGE = "This office hour is owned by another user"
 
 
-@python_2_unicode_compatible
 class BaseMentorProgramOfficeHour(AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_model_change.py
+++ b/accelerator_abstract/models/base_model_change.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -23,7 +22,6 @@ MODEL_CHANGE_STATUSES = [
 MODEL_CHANGE_STATUS_CHOICES = [(x, x) for x in MODEL_CHANGE_STATUSES]
 
 
-@python_2_unicode_compatible
 class BaseModelChange(AcceleratorModel):
     name = models.CharField(max_length=128, unique=True)
     status = models.CharField(max_length=64,

--- a/accelerator_abstract/models/base_newsletter_receipt.py
+++ b/accelerator_abstract/models/base_newsletter_receipt.py
@@ -8,14 +8,12 @@ import logging
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 logger = logging.getLogger(__file__)
 
 
-@python_2_unicode_compatible
 class BaseNewsletterReceipt(AcceleratorModel):
     newsletter = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, 'Newsletter'),

--- a/accelerator_abstract/models/base_node_published_for.py
+++ b/accelerator_abstract/models/base_node_published_for.py
@@ -5,13 +5,11 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from fluent_pages.models import UrlNode
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseNodePublishedFor(AcceleratorModel):
     node = models.ForeignKey(UrlNode, on_delete=models.CASCADE)
     published_for = models.ForeignKey(

--- a/accelerator_abstract/models/base_observer.py
+++ b/accelerator_abstract/models/base_observer.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseObserver(AcceleratorModel):
     first_name = models.CharField(max_length=50, blank=True, null=True)
     last_name = models.CharField(max_length=50)

--- a/accelerator_abstract/models/base_panel.py
+++ b/accelerator_abstract/models/base_panel.py
@@ -11,7 +11,6 @@ from django.db.models import (
     ManyToManyField,
     CASCADE,
 )
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -29,7 +28,6 @@ PANEL_AVAILABILITY_KEYWORD_SLOTS = {'time': 'panel_time',
                                     'location': 'location'}
 
 
-@python_2_unicode_compatible
 class BasePanel(AcceleratorModel):
     judges = ManyToManyField(
         settings.AUTH_USER_MODEL,

--- a/accelerator_abstract/models/base_panel_location.py
+++ b/accelerator_abstract/models/base_panel_location.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BasePanelLocation(AcceleratorModel):
     location = models.CharField(max_length=225, primary_key=True)
     description = models.CharField(max_length=225)

--- a/accelerator_abstract/models/base_panel_time.py
+++ b/accelerator_abstract/models/base_panel_time.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 from accelerator_abstract.utils import (
@@ -14,7 +13,6 @@ from accelerator_abstract.utils import (
 )
 
 
-@python_2_unicode_compatible
 class BasePanelTime(AcceleratorModel):
     day = models.CharField(max_length=255)
     time = models.CharField(max_length=255)

--- a/accelerator_abstract/models/base_panel_type.py
+++ b/accelerator_abstract/models/base_panel_type.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BasePanelType(AcceleratorModel):
     panel_type = models.CharField(max_length=225, primary_key=True)
     description = models.CharField(max_length=225)

--- a/accelerator_abstract/models/base_partner.py
+++ b/accelerator_abstract/models/base_partner.py
@@ -5,13 +5,11 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from sorl.thumbnail import ImageField
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BasePartner(AcceleratorModel):
     organization = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_partner_team_member.py
+++ b/accelerator_abstract/models/base_partner_team_member.py
@@ -6,12 +6,10 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BasePartnerTeamMember(AcceleratorModel):
     partner = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Partner"),

--- a/accelerator_abstract/models/base_paypal_payment.py
+++ b/accelerator_abstract/models/base_paypal_payment.py
@@ -12,7 +12,8 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
 # Conforming to the django-paypal convention of using
-# PayPal in CamelCase and paypal in snake_case.class BasePayPalPayment(AcceleratorModel):
+# PayPal in CamelCase and paypal in snake_case.
+class BasePayPalPayment(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),
         on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_paypal_payment.py
+++ b/accelerator_abstract/models/base_paypal_payment.py
@@ -12,8 +12,7 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
 # Conforming to the django-paypal convention of using
-# PayPal in CamelCase and paypal in snake_case.@python_2_unicode_compatible
-class BasePayPalPayment(AcceleratorModel):
+# PayPal in CamelCase and paypal in snake_case.class BasePayPalPayment(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),
         on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_paypal_refund.py
+++ b/accelerator_abstract/models/base_paypal_refund.py
@@ -12,8 +12,7 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
 # Conforming to the django-paypal convention of using
-# PayPal in CamelCase and paypal in snake_case.@python_2_unicode_compatible
-class BasePayPalRefund(AcceleratorModel):
+# PayPal in CamelCase and paypal in snake_case.class BasePayPalRefund(AcceleratorModel):
     payment = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,
                                "PayPalPayment"),

--- a/accelerator_abstract/models/base_paypal_refund.py
+++ b/accelerator_abstract/models/base_paypal_refund.py
@@ -12,7 +12,8 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
 # Conforming to the django-paypal convention of using
-# PayPal in CamelCase and paypal in snake_case.class BasePayPalRefund(AcceleratorModel):
+# PayPal in CamelCase and paypal in snake_case.
+class BasePayPalRefund(AcceleratorModel):
     payment = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,
                                "PayPalPayment"),

--- a/accelerator_abstract/models/base_program_family_location.py
+++ b/accelerator_abstract/models/base_program_family_location.py
@@ -2,12 +2,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseProgramFamilyLocation(AcceleratorModel):
     program_family = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_program_override.py
+++ b/accelerator_abstract/models/base_program_override.py
@@ -7,12 +7,10 @@ import decimal
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseProgramOverride(AcceleratorModel):
     cycle = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_program_partner.py
+++ b/accelerator_abstract/models/base_program_partner.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseProgramPartner(AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_program_partner_type.py
+++ b/accelerator_abstract/models/base_program_partner_type.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from sorl.thumbnail import ImageField
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
@@ -17,7 +16,6 @@ PARTNER_BADGE_DISPLAY_VALUES = (
     ('PARTNER_LIST_AND_PROFILE', 'Partner list and profile'))
 
 
-@python_2_unicode_compatible
 class BaseProgramPartnerType(AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_program_role_grant.py
+++ b/accelerator_abstract/models/base_program_role_grant.py
@@ -6,12 +6,10 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseProgramRoleGrant(AcceleratorModel):
     person = models.ForeignKey(settings.AUTH_USER_MODEL,
                                on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_program_startup_attribute.py
+++ b/accelerator_abstract/models/base_program_startup_attribute.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -17,7 +16,6 @@ PROGRAM_STARTUP_ATTRIBUTE_TYPES = (
 )
 
 
-@python_2_unicode_compatible
 class BaseProgramStartupAttribute(AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_program_startup_status.py
+++ b/accelerator_abstract/models/base_program_startup_status.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from sorl.thumbnail import ImageField
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
@@ -22,7 +21,6 @@ STARTUP_BADGE_DISPLAY_VALUES = (
     (BADGE_STARTUP_LIST_AND_PROFILE, 'Startup list and profile'))
 
 
-@python_2_unicode_compatible
 class BaseProgramStartupStatus(AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_reference.py
+++ b/accelerator_abstract/models/base_reference.py
@@ -7,12 +7,10 @@ import swapper
 from django.conf import settings
 from django.core.validators import EmailValidator
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseReference(AcceleratorModel):
     application = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Application"),

--- a/accelerator_abstract/models/base_refund_code.py
+++ b/accelerator_abstract/models/base_refund_code.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -13,7 +12,6 @@ from accelerator_abstract.models.accelerator_model import AcceleratorModel
 # DO NOT DELETE NEXT LINE:
 # It is necessary to be able to mock out PayPalWPP
 
-@python_2_unicode_compatible
 class BaseRefundCode(AcceleratorModel):
     unique_code = models.CharField(max_length=100, unique=True)
     programs = models.ManyToManyField(

--- a/accelerator_abstract/models/base_refund_code_redemption.py
+++ b/accelerator_abstract/models/base_refund_code_redemption.py
@@ -7,7 +7,6 @@ import decimal
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 from accelerator_abstract.models.base_application import REFUND_STATUSES
@@ -16,7 +15,6 @@ CREDIT_CODE_NOT_AVAILABLE = ("Apologies, credit code %s "
                              "is no longer available")
 
 
-@python_2_unicode_compatible
 class BaseRefundCodeRedemption(AcceleratorModel):
     refund_code = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "RefundCode"),

--- a/accelerator_abstract/models/base_scenario_application.py
+++ b/accelerator_abstract/models/base_scenario_application.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseScenarioApplication(AcceleratorModel):
     application = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Application"),

--- a/accelerator_abstract/models/base_scenario_judge.py
+++ b/accelerator_abstract/models/base_scenario_judge.py
@@ -6,12 +6,10 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseScenarioJudge(AcceleratorModel):
     judge = models.ForeignKey(settings.AUTH_USER_MODEL,
                               on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_scenario_preference.py
+++ b/accelerator_abstract/models/base_scenario_preference.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -80,7 +79,6 @@ ENTITY_TYPES = (
     (APPLICATION_ENTITY, 'application'))
 
 
-@python_2_unicode_compatible
 class BaseScenarioPreference(AcceleratorModel):
     scenario = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Scenario"),

--- a/accelerator_abstract/models/base_section.py
+++ b/accelerator_abstract/models/base_section.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -17,7 +16,6 @@ INCLUDE_FOR_CHOICES = (('EVERYONE', 'Everyone'),
 SECTION_SEQUENCE_HELP = "specify the order of this section in the newsletter"
 
 
-@python_2_unicode_compatible
 class BaseSection(AcceleratorModel):
     heading = models.CharField(max_length=255, blank=True)
     body = models.TextField(blank=True)

--- a/accelerator_abstract/models/base_site.py
+++ b/accelerator_abstract/models/base_site.py
@@ -4,12 +4,10 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseSite(AcceleratorModel):
     name = models.CharField(max_length=50, unique=True)
     security_key = models.CharField(max_length=100)

--- a/accelerator_abstract/models/base_site_program_authorization.py
+++ b/accelerator_abstract/models/base_site_program_authorization.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseSiteProgramAuthorization(AcceleratorModel):
     site = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Site"),

--- a/accelerator_abstract/models/base_startup.py
+++ b/accelerator_abstract/models/base_startup.py
@@ -9,7 +9,6 @@ import swapper
 from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from embed_video.fields import EmbedVideoField
 from sorl.thumbnail import ImageField
@@ -32,7 +31,6 @@ STARTUP_NO_ORG_WARNING_MSG = "Startup {} has no organization"
 DISPLAY_STARTUP_STATUS = "{status} {year} ({program_family_slug})"
 
 
-@python_2_unicode_compatible
 class BaseStartup(AcceleratorModel):
     organization = models.ForeignKey(swapper.get_model_name(
         AcceleratorModel.Meta.app_label, 'Organization'), blank=True,

--- a/accelerator_abstract/models/base_startup_label.py
+++ b/accelerator_abstract/models/base_startup_label.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.label_model import LabelModel
 
 
-@python_2_unicode_compatible
 class BaseStartupLabel(LabelModel):
     label = models.CharField(max_length=LabelModel.LABEL_LENGTH)
     startups = models.ManyToManyField(

--- a/accelerator_abstract/models/base_startup_mentor_relationship.py
+++ b/accelerator_abstract/models/base_startup_mentor_relationship.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -18,7 +17,6 @@ RELATIONSHIP_CHOICES = ((CONFIRMED_RELATIONSHIP, CONFIRMED_RELATIONSHIP),
                         (DESIRED_RELATIONSHIP, DESIRED_RELATIONSHIP))
 
 
-@python_2_unicode_compatible
 class BaseStartupMentorRelationship(AcceleratorModel):
     startup_mentor_tracking = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label,

--- a/accelerator_abstract/models/base_startup_mentor_tracking_record.py
+++ b/accelerator_abstract/models/base_startup_mentor_tracking_record.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
@@ -25,7 +24,6 @@ PROGRAM_GOALS_HELP = ("Submit the three goals you plan to work on "
                       "with your mentors during the accelerator program.")
 
 
-@python_2_unicode_compatible
 class BaseStartupMentorTrackingRecord(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),

--- a/accelerator_abstract/models/base_startup_override_grant.py
+++ b/accelerator_abstract/models/base_startup_override_grant.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseStartupOverrideGrant(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),

--- a/accelerator_abstract/models/base_startup_program_interest.py
+++ b/accelerator_abstract/models/base_startup_program_interest.py
@@ -7,7 +7,6 @@ import logging
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from ordered_model.models import OrderedModel
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
@@ -27,7 +26,6 @@ PROGRAM_INTEREST_UP = 'up'
 PROGRAM_INTEREST_DOWN = 'down'
 
 
-@python_2_unicode_compatible
 class BaseStartupProgramInterest(OrderedModel, AcceleratorModel):
     program = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Program"),

--- a/accelerator_abstract/models/base_startup_role.py
+++ b/accelerator_abstract/models/base_startup_role.py
@@ -4,12 +4,10 @@
 from __future__ import unicode_literals
 
 from django.db.models import CharField
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseStartupRole(AcceleratorModel):
     # Known Startup Roles
     FINALIST = "Finalist"

--- a/accelerator_abstract/models/base_startup_status.py
+++ b/accelerator_abstract/models/base_startup_status.py
@@ -5,12 +5,10 @@ from __future__ import unicode_literals
 
 import swapper
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseStartupStatus(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),

--- a/accelerator_abstract/models/base_startup_team_member.py
+++ b/accelerator_abstract/models/base_startup_team_member.py
@@ -6,12 +6,10 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseStartupTeamMember(AcceleratorModel):
     startup = models.ForeignKey(
         swapper.get_model_name(AcceleratorModel.Meta.app_label, "Startup"),

--- a/accelerator_abstract/models/base_user_label.py
+++ b/accelerator_abstract/models/base_user_label.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.label_model import LabelModel
 
@@ -14,7 +13,6 @@ DESIRED_JUDGE_STATE = "Desired"
 CONFIRMED_JUDGE_STATE = "Confirmed"
 
 
-@python_2_unicode_compatible
 class BaseUserLabel(LabelModel):
     label = models.CharField(max_length=LabelModel.LABEL_LENGTH)
     users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True)

--- a/accelerator_abstract/models/base_user_legal_check.py
+++ b/accelerator_abstract/models/base_user_legal_check.py
@@ -8,12 +8,10 @@ from __future__ import unicode_literals
 import swapper
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models.accelerator_model import AcceleratorModel
 
 
-@python_2_unicode_compatible
 class BaseUserLegalCheck(AcceleratorModel):
     user = models.ForeignKey(
         to=settings.AUTH_USER_MODEL,

--- a/simpleuser/models.py
+++ b/simpleuser/models.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import BaseUserManager
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 
 from accelerator_abstract.models import BaseUserRole
 from accelerator_abstract.models.base_base_profile import EXPERT_USER_TYPE
@@ -56,7 +55,6 @@ class UserManager(BaseUserManager):
                                  **extra_fields)
 
 
-@python_2_unicode_compatible
 class User(AbstractUser):
     # Override the parent email field to add uniqueness constraint
     email = models.EmailField(blank=True, unique=True)


### PR DESCRIPTION
## [AC-8495](https://masschallenge.atlassian.net/browse/AC-8495)

Review suggestions:
* Confirm all unit tests pass
* Research and confirm `django.utils.encoding.python_2_unicode_compatible` is a noop under Python 3
* Confirm that none of the touched files run under Python 2
