### PR TITLE
[AC-8673] Eliminate warning: naive datetime

### DIFF
--- a/accelerator/tests/factories/user_deferrable_modal_factory.py
+++ b/accelerator/tests/factories/user_deferrable_modal_factory.py
@@ -6,6 +6,8 @@ from datetime import (
 )
 from factory import SubFactory
 from factory.django import DjangoModelFactory
+from pytz import utc
+
 from simpleuser.tests.factories.user_factory import UserFactory
 from .deferrable_modal_factory import DeferrableModalFactory
 
@@ -20,4 +22,4 @@ class UserDeferrableModalFactory(DjangoModelFactory):
     user = SubFactory(UserFactory)
     deferrable_modal = SubFactory(DeferrableModalFactory)
     is_deferred = False
-    deferred_to = datetime.now() + timedelta(days=1)
+    deferred_to = utc.localize(datetime.now()) + timedelta(days=1)


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-8673

Fixed a factory which provided a bare datetime. 

See sibling PR on accelerate.