### PR TITLE
[AC-8373] make gender field optional

### DIFF
--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -62,7 +62,8 @@ class BaseCoreProfile(AcceleratorModel):
     gender = models.CharField(
         max_length=1,
         choices=GENDER_CHOICES,
-        default='')
+        default='',
+        blank=True)
     gender_identity = models.ManyToManyField(
         swapper.get_model_name(
             AcceleratorModel.Meta.app_label, 'GenderChoices'),


### PR DESCRIPTION
Changes introduced in [AC-8373](https://masschallenge.atlassian.net/browse/AC-8373)
- this change makes the gender field in the base_core_profile optional
- this is a pre-requisite for these PRs:

https://github.com/masschallenge/accelerate/pull/2938
https://github.com/masschallenge/django-accelerator/pull/401

How to test:
- You can register as an entrepreneur or expert while checking out https://github.com/masschallenge/accelerate/pull/2938 successfully.