### PR TITLE
[AC-8802] Ensure that CoreProfile has functions needed for Startup membership/ownership

### DIFF
--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -270,9 +270,8 @@ class TestCoreProfile(TestCase):
 
 def _user_is_alum_in_residence(air_program=None, non_air_program=None):
     user = EntrepreneurFactory()
-    if air_program:
-        user = EntrepreneurFactory(profile__current_program=air_program)
-    context = UserRoleContext(BaseUserRole.AIR, user=user)
+    context = UserRoleContext(
+        BaseUserRole.AIR, user=user, program=air_program)
     user_profile = context.user.get_profile()
     program_of_interest = non_air_program or air_program
     if program_of_interest:

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -124,7 +124,7 @@ class TestCoreProfile(TestCase):
         self.assertTrue(
             profile.interest_category_names() == [interest_category.name])
 
-    def test_is_alum_in_residence(self):
+    def test_expert_is_alum_in_residence(self):
         user = expert(BaseUserRole.AIR)
         profile = user.get_profile()
         self.assertTrue(profile.is_alum_in_residence())

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -253,3 +253,28 @@ class TestCoreProfile(TestCase):
         user_profile = EntrepreneurProfileFactory(landing_page="/")
         landing_page = user_profile.check_landing_page()
         self.assertEqual(landing_page, user_profile.default_page)
+
+    def test_is_alum_in_residence(self):
+        self.assertTrue(_user_is_alum_in_residence())
+
+    def test_is_alum_in_residence_returns_true_if_in_program(self):
+        air_program = ProgramFactory()
+        self.assertTrue(_user_is_alum_in_residence(air_program))
+
+    def test_is_alum_in_residence_returns_false_if_not_in_program(self):
+        air_program = ProgramFactory()
+        non_air_program = ProgramFactory()
+        self.assertFalse(_user_is_alum_in_residence(
+            air_program, non_air_program))
+
+
+def _user_is_alum_in_residence(air_program=None, non_air_program=None):
+    user = EntrepreneurFactory()
+    if air_program:
+        user = EntrepreneurFactory(profile__current_program=air_program)
+    context = UserRoleContext(BaseUserRole.AIR, user=user)
+    user_profile = context.user.get_profile()
+    program_of_interest = non_air_program or air_program
+    if program_of_interest:
+        return user_profile.is_alum_in_residence(program_of_interest)
+    return user_profile.is_alum_in_residence()

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -311,8 +311,7 @@ class BaseCoreProfile(AcceleratorModel):
                 startup__startupstatus__program_startup_status__in=statuses)
         if startup_memberships:
             return startup_memberships.first().startup
-        else:
-            return None
+        return None
 
     def interest_category_names(self):
         return [interest.name for interest in self.interest_categories.all()]

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -20,7 +20,6 @@ from accelerator_abstract.models.base_user_role import (
     BaseUserRole,
 )
 from accelerator_abstract.models.base_base_profile import (
-    ENTREPRENEUR_USER_TYPE,
     EXPERT_USER_TYPE,
 )
 from accelerator_abstract.models.base_user_utils import (

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -189,7 +189,7 @@ class BaseCoreProfile(AcceleratorModel):
         return qs.exists()
 
     def is_alum_in_residence(self, program=None):
-        if self.user_type == ENTREPRENEUR_USER_TYPE:
+        if self.user_type == ENTREPRENEUR_USER_TYPE.lower():
             qs = self.user.programrolegrant_set.filter(
                 program_role__user_role__name=BaseUserRole.AIR,
                 program_role__program__exact=self.current_program)

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -20,6 +20,7 @@ from accelerator_abstract.models.base_user_role import (
     BaseUserRole,
 )
 from accelerator_abstract.models.base_base_profile import (
+    ENTREPRENEUR_USER_TYPE,
     EXPERT_USER_TYPE,
 )
 from accelerator_abstract.models.base_user_utils import (
@@ -188,16 +189,17 @@ class BaseCoreProfile(AcceleratorModel):
         return qs.exists()
 
     def is_alum_in_residence(self, program=None):
-        if self.user_type == EXPERT_USER_TYPE:
+        if self.user_type == ENTREPRENEUR_USER_TYPE:
+            qs = self.user.programrolegrant_set.filter(
+                program_role__user_role__name=BaseUserRole.AIR,
+                program_role__program__exact=self.current_program)
+            if program:
+                qs = qs.filter(program_role__program=program)
+            return qs.exists()
+        else:
             return self.user.programrolegrant_set.filter(
                 program_role__user_role__name=BaseUserRole.AIR
             ).exists()
-        qs = self.user.programrolegrant_set.filter(
-            program_role__user_role__name=BaseUserRole.AIR,
-            program_role__program__exact=self.current_program)
-        if program:
-            qs = qs.filter(program_role__program=program)
-        return qs.exists()
 
     def is_mentor(self, program=None):
         """If program is specified, is the expert a mentor in that program.

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -189,17 +189,11 @@ class BaseCoreProfile(AcceleratorModel):
         return qs.exists()
 
     def is_alum_in_residence(self, program=None):
-        if self.user_type == ENTREPRENEUR_USER_TYPE.lower():
-            qs = self.user.programrolegrant_set.filter(
-                program_role__user_role__name=BaseUserRole.AIR,
-                program_role__program__exact=self.current_program)
-            if program:
-                qs = qs.filter(program_role__program=program)
-            return qs.exists()
-        else:
-            return self.user.programrolegrant_set.filter(
-                program_role__user_role__name=BaseUserRole.AIR
-            ).exists()
+        qs = self.user.programrolegrant_set.filter(
+            program_role__user_role__name=BaseUserRole.AIR)
+        if program:
+            qs = qs.filter(program_role__program=program)
+        return qs.exists()
 
     def is_mentor(self, program=None):
         """If program is specified, is the expert a mentor in that program.


### PR DESCRIPTION
## [AC-8802](https://masschallenge.atlassian.net/browse/AC-8802)

**Changes introduced**
- move functions needed for Startup membership/ownership to CoreProfile

**Testing**
- Confirm that the following def of done conditions are met:
  - move is_alum_in_residence and first_startup onto CoreProfile
  - make add no-op get_active_alerts to EntrepreneurProfile
  - Result of this ticket: EntrepreneurProfile defines no functions

[Sibling PR](https://github.com/masschallenge/accelerate/pull/2959)