### PR TITLE
[AC-9028] Create algolia index for community directory

### DIFF
--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -23,7 +23,8 @@ SHORT_BIO_MAX_LENGTH = 140
 OFFICE_HOUR_HOLDER_ROLES = [UserRole.MENTOR, UserRole.AIR]
 OFFICE_HOURS_HOLDER = Q(
     program_role__user_role__name__in=OFFICE_HOUR_HOLDER_ROLES)
-ACTIVE_PROGRAM = Q(program_role__program__program_status='active')
+HAS_ACTIVE_PROGRAM_STATUS = Q(
+    program_role__program__program_status=ACTIVE_PROGRAM_STATUS)
 
 
 class CoreProfile(BaseCoreProfile, PolymorphicModel):
@@ -164,7 +165,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         participation_roles = [UserRole.MENTOR, UserRole.FINALIST]
         return list(self.user.programrolegrant_set.filter(
             Q(program_role__user_role__name__in=participation_roles)
-            & ACTIVE_PROGRAM).values_list(
+            & HAS_ACTIVE_PROGRAM_STATUS).values_list(
             'program_role__program__name', flat=True).distinct())
 
     def _trimmed_bio(self, max_chars):
@@ -212,6 +213,6 @@ def _get_office_hour_holder_active_programs(user):
         'program_family__programs__id', flat=True
     ).distinct()))
     active_program_ids.update(list(user.programrolegrant_set.filter(
-        OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM
+        OFFICE_HOURS_HOLDER & HAS_ACTIVE_PROGRAM_STATUS
     ).values_list('program_role__program__id', flat=True).distinct()))
     return active_program_ids

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -1,14 +1,21 @@
 import swapper
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import (
+    OuterRef,
+    Q,
+    Subquery,
+)
 from django.urls import reverse
 from django.utils import timezone
 from polymorphic.models import PolymorphicModel
 
 from accelerator.models import UserRole
-from accelerator_abstract.models import (ACTIVE_PROGRAM_STATUS, BIO_MAX_LENGTH,
-                                         ENDED_PROGRAM_STATUS,
-                                         HIDDEN_PROGRAM_STATUS,
-                                         UPCOMING_PROGRAM_STATUS)
+from accelerator_abstract.models import (
+    ACTIVE_PROGRAM_STATUS,
+    BIO_MAX_LENGTH,
+    ENDED_PROGRAM_STATUS,
+    HIDDEN_PROGRAM_STATUS,
+    UPCOMING_PROGRAM_STATUS,
+)
 from accelerator_abstract.models.base_core_profile import BaseCoreProfile
 
 SHORT_BIO_MAX_LENGTH = 140
@@ -142,6 +149,13 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         if has_available_office_hours:
             return list(_get_office_hour_holder_active_programs(self.user))
         return []
+
+    def program_participation(self):
+        participation_roles = [UserRole.MENTOR, UserRole.FINALIST]
+        return self.user.programrolegrant_set.filter(
+            Q(program_role__user_role__name__in=participation_roles)
+            & ACTIVE_PROGRAM).values_list(
+            'program_role__program__name', flat=True).distinct()
 
     def _trimmed_bio(self, max_chars):
         bio = self.bio or ''

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -1,13 +1,195 @@
-# MIT License
-# Copyright (c) 2017 MassChallenge, Inc.
-
-from __future__ import unicode_literals
-
+import swapper
+from django.db.models import OuterRef, Q, Subquery
+from django.urls import reverse
+from django.utils import timezone
 from polymorphic.models import PolymorphicModel
 
+from accelerator.models import UserRole
+from accelerator_abstract.models import (ACTIVE_PROGRAM_STATUS, BIO_MAX_LENGTH,
+                                         ENDED_PROGRAM_STATUS,
+                                         HIDDEN_PROGRAM_STATUS,
+                                         UPCOMING_PROGRAM_STATUS)
 from accelerator_abstract.models.base_core_profile import BaseCoreProfile
+
+SHORT_BIO_MAX_LENGTH = 140
+OFFICE_HOUR_HOLDER_ROLES = [UserRole.MENTOR, UserRole.AIR]
+OFFICE_HOURS_HOLDER = Q(
+    program_role__user_role__name__in=OFFICE_HOUR_HOLDER_ROLES)
+ACTIVE_PROGRAM = Q(program_role__program__program_status='active')
 
 
 class CoreProfile(BaseCoreProfile, PolymorphicModel):
     class Meta(BaseCoreProfile.Meta):
         pass
+
+    def first_name(self):
+        return self.user.first_name
+
+    def last_name(self):
+        return self.user.last_name
+
+    def startup_name(self):
+        return self.user.startup_name()
+
+    def email(self):
+        return self.user.email
+
+    def program(self):
+        return self.user.program()
+
+    def startup_industry(self):
+        return self.user.startup_industry()
+
+    def startup_status_names(self):
+        self.user.startup_status_names()
+
+    def location(self):
+        return self.user.location()
+
+    def year(self):
+        return self.user.year()
+
+    def type(self):
+        return self.user.type()
+
+    def team_member_id(self):
+        return self.user.team_member_id()
+
+    def user_title(self):
+        return self.user.user_title()
+
+    def finalist_user_roles(self):
+        return self.user.finalist_user_roles()
+
+    def is_team_member(self):
+        return self.user.is_team_member()
+
+    def top_level_startup_industry(self):
+        return self.user.top_level_startup_industry()
+
+    def has_a_finalist_role(self):
+        return self.user.has_a_finalist_role()
+
+    def is_active(self):
+        return self.user.is_active
+
+    @property
+    def long_bio(self):
+        return self._trimmed_bio(max_chars=BIO_MAX_LENGTH)
+
+    @property
+    def short_bio(self):
+        return self._trimmed_bio(max_chars=SHORT_BIO_MAX_LENGTH)
+
+    @property
+    def mentor_profile_url(self):
+        if self.is_mentor():
+            return reverse('mentor_view', args=(self.user.id,))
+
+    def is_confirmed_mentor(self):
+        return self.user.programrolegrant_set.filter(
+            program_role__user_role__name=UserRole.MENTOR).exists()
+
+    def confirmed_mentor_program_families(self):
+        """
+        Given that the Mentor Directory should not be empty,
+        When all programs in a program family have ended
+        We want to be able to show the mentors in the ended program
+        But when a program is active, we shouldn't show the confirmed
+        mentors of the ended program.
+        SubQueries were leveraged for optimisation to reduce
+        the number of queries.
+        """
+        prg = self._confirmed_non_future_program_role_grant()
+        program_ids = self._latest_program_id_foreach_program_family()
+        return list(prg.filter(
+            program_role__program__pk__in=program_ids
+        ).values_list(
+            'program_role__program__program_family__name',
+            flat=True).distinct())
+
+    def latest_active_program_location(self):
+        prg = self._latest_confirmed_non_future_program_role_grant()
+        if not prg:
+            return None
+        return prg.program_role.program.program_family.name
+
+    def latest_active_program_year(self):
+        prg = self._latest_confirmed_non_future_program_role_grant()
+        if not prg:
+            return None
+        return str(prg.program_role.program.start_date.year)
+
+    def functional_expertise_names(self):
+        return [
+            expertise.name for expertise in self.functional_expertise.all()]
+
+    def mentoring_specialty_names(self):
+        return [
+            str(specialty) for specialty in self.mentoring_specialties.all()]
+
+    def additional_industry_names(self):
+        return [
+            industry.name for industry in self.additional_industries.all()]
+
+    def office_hour_programs(self):
+        # returns a list of all active program ids associated with an expert
+        # having open office hours
+        has_available_office_hours = self.user.mentor_officehours.filter(
+            finalist__isnull=True,
+            start_date_time__gte=timezone.now()
+        ).exists()
+        if has_available_office_hours:
+            return list(_get_office_hour_holder_active_programs(self.user))
+        return []
+
+    def _trimmed_bio(self, max_chars):
+        bio = self.bio or ''
+        if len(bio) > max_chars:
+            bio = bio[:max_chars].rsplit(' ', 1)[0]
+            bio = '%s...' % bio
+        return bio
+
+    def _confirmed_non_future_program_role_grant(self):
+        return self.user.programrolegrant_set.filter(
+            program_role__user_role__name=UserRole.MENTOR).exclude(
+            program_role__program__program_status__in=[
+                HIDDEN_PROGRAM_STATUS,
+                UPCOMING_PROGRAM_STATUS]
+        ).prefetch_related(
+            'program_role__program',
+            'program_role__program__program_family'
+        )
+
+    def _latest_program_id_foreach_program_family(self):
+        ProgramFamily = swapper.load_model('accelerator', 'ProgramFamily')
+        latest_program_subquery = self._program_family__program_subquery()
+        return list(ProgramFamily.objects.annotate(
+            latest_program=Subquery(latest_program_subquery)
+        ).values_list("latest_program", flat=True))
+
+    def _latest_confirmed_non_future_program_role_grant(self):
+        prg = self._confirmed_non_future_program_role_grant()
+        return prg.order_by('-created_at').first()
+
+    def _program_family__program_subquery(self):
+        Program = swapper.load_model('accelerator', 'Program')
+        return Program.objects.filter(
+            program_family=OuterRef('pk'),
+            program_status__in=[ACTIVE_PROGRAM_STATUS, ENDED_PROGRAM_STATUS]
+        ).order_by("-created_at").values('pk')[:1]
+
+
+def _get_office_hour_holder_active_programs(user):
+    Clearance = swapper.load_model('accelerator', 'Clearance')
+    clearances = Clearance.objects.clearances_for_user(user).filter(
+        program_family__programs__program_status=ACTIVE_PROGRAM_STATUS
+    )
+    active_program_ids = set()
+    active_program_ids.update(list(clearances.values_list(
+        'program_family__programs__id', flat=True
+    ).distinct()))
+    active_program_ids.update(list(user.programrolegrant_set.filter(
+        OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM
+    ).values_list('program_role__program__id', flat=True).distinct()))
+    return active_program_ids

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -49,7 +49,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         return self.user.startup_industry()
 
     def startup_status_names(self):
-        self.user.startup_status_names()
+        return self.user.startup_status_names()
 
     def location(self):
         return self.user.location()

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -145,8 +145,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         # having open office hours
         has_available_office_hours = self.user.mentor_officehours.filter(
             finalist__isnull=True,
-            start_date_time__gte=timezone.now()
-        ).exists()
+            start_date_time__gte=timezone.now()).exists()
         if has_available_office_hours:
             return list(_get_office_hour_holder_active_programs(self.user))
         return []
@@ -183,8 +182,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
                 UPCOMING_PROGRAM_STATUS]
         ).prefetch_related(
             'program_role__program',
-            'program_role__program__program_family'
-        )
+            'program_role__program__program_family')
 
     def _latest_program_id_foreach_program_family(self):
         ProgramFamily = swapper.load_model('accelerator', 'ProgramFamily')
@@ -208,8 +206,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
 def _get_office_hour_holder_active_programs(user):
     Clearance = swapper.load_model('accelerator', 'Clearance')
     clearances = Clearance.objects.clearances_for_user(user).filter(
-        program_family__programs__program_status=ACTIVE_PROGRAM_STATUS
-    )
+        program_family__programs__program_status=ACTIVE_PROGRAM_STATUS)
     active_program_ids = set()
     active_program_ids.update(list(clearances.values_list(
         'program_family__programs__id', flat=True

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -23,7 +23,7 @@ SHORT_BIO_MAX_LENGTH = 140
 OFFICE_HOUR_HOLDER_ROLES = [UserRole.MENTOR, UserRole.AIR]
 OFFICE_HOURS_HOLDER = Q(
     program_role__user_role__name__in=OFFICE_HOUR_HOLDER_ROLES)
-HAS_ACTIVE_PROGRAM_STATUS = Q(
+ACTIVE_PROGRAM = Q(
     program_role__program__program_status=ACTIVE_PROGRAM_STATUS)
 
 
@@ -165,7 +165,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         participation_roles = [UserRole.MENTOR, UserRole.FINALIST]
         return list(self.user.programrolegrant_set.filter(
             Q(program_role__user_role__name__in=participation_roles)
-            & HAS_ACTIVE_PROGRAM_STATUS).values_list(
+            & ACTIVE_PROGRAM).values_list(
             'program_role__program__name', flat=True).distinct())
 
     def _trimmed_bio(self, max_chars):
@@ -213,6 +213,6 @@ def _get_office_hour_holder_active_programs(user):
         'program_family__programs__id', flat=True
     ).distinct()))
     active_program_ids.update(list(user.programrolegrant_set.filter(
-        OFFICE_HOURS_HOLDER & HAS_ACTIVE_PROGRAM_STATUS
+        OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM
     ).values_list('program_role__program__id', flat=True).distinct()))
     return active_program_ids

--- a/accelerator/models/expert_profile.py
+++ b/accelerator/models/expert_profile.py
@@ -1,43 +1,24 @@
 import swapper
+from pytz import utc
 
 from datetime import datetime
-from django.db.models import (
-    OuterRef,
-    Q,
-    Subquery
-)
+from django.db.models import Q
 from django.urls import reverse
-from django.utils import timezone
-from pytz import utc
+
 from accelerator.models import (
     CoreProfile,
-    UserRole,
-)
+    UserRole)
 from accelerator.utils import UserAlert
 from accelerator_abstract.models import (
     ACTIVE_PANEL_STATUS,
-    ACTIVE_PROGRAM_STATUS,
-    BIO_MAX_LENGTH,
-    CAPTURE_AVAILABILITY_DISABLED,
-    ENDED_PROGRAM_STATUS,
-    HIDDEN_PROGRAM_STATUS,
-    UPCOMING_PROGRAM_STATUS,
-)
-from accelerator_abstract.models.base_judging_round import (
-    ONLINE_JUDGING_ROUND_TYPE,
-)
+    CAPTURE_AVAILABILITY_DISABLED)
+from accelerator_abstract.models.base_judging_round import ONLINE_JUDGING_ROUND_TYPE
 
-SHORT_BIO_MAX_LENGTH = 140
 CONFIRMED_FOR_MESSAGE = "<h4>%s, you are confirmed for %s:</h4>"
 EXPECTING_TO_SEE_YOU_MESSAGE = ("<p>&nbsp;</p><h4>We are expecting "
                                 "to see you at %s.</h4>")
 SINGLE_PANEL_MESSAGE = "this upcoming judging panel"
 MULTIPLE_PANELS_MESSAGE = "these upcoming judging panels"
-OFFICE_HOUR_HOLDER_ROLES = [UserRole.MENTOR, UserRole.AIR]
-OFFICE_HOURS_HOLDER = Q(
-    program_role__user_role__name__in=OFFICE_HOUR_HOLDER_ROLES)
-ACTIVE_PROGRAM = Q(program_role__program__program_status='active')
-
 PLEASE_INFORM_US_MESSAGE = ("<p>&nbsp;</p><p><b>PLEASE INFORM US IMMEDIATELY "
                             'AT <a href="mailto:%s">%s</a>'
                             "IF YOU ARE NO LONGER ABLE TO MAKE %s. "
@@ -79,49 +60,8 @@ class ExpertProfile(CoreProfile):
     def judge_round_commitments(self):
         return self.user.judgeroundcommitment_set.all()
 
-    @property
-    def long_bio(self):
-        return self._trimmed_bio(max_chars=BIO_MAX_LENGTH)
-
-    @property
-    def short_bio(self):
-        return self._trimmed_bio(max_chars=SHORT_BIO_MAX_LENGTH)
-
-    @property
-    def mentor_profile_url(self):
-        if self.is_mentor():
-            return reverse('mentor_view', args=(self.user.id,))
-
-    def _trimmed_bio(self, max_chars):
-        bio = self.bio or ''
-        if len(bio) > max_chars:
-            bio = bio[:max_chars].rsplit(' ', 1)[0]
-            bio = '%s...' % bio
-        return bio
-
     def user_id(self):
         return self.user.id
-
-    def first_name(self):
-        return self.user.first_name
-
-    def last_name(self):
-        return self.user.last_name
-
-    def email(self):
-        return self.user.email
-
-    def mentoring_specialty_names(self):
-        return [
-            str(specialty) for specialty in self.mentoring_specialties.all()]
-
-    def additional_industry_names(self):
-        return [
-            industry.name for industry in self.additional_industries.all()]
-
-    def functional_expertise_names(self):
-        return [
-            expertise.name for expertise in self.functional_expertise.all()]
 
     @property
     def active_round(self):
@@ -251,68 +191,6 @@ class ExpertProfile(CoreProfile):
         else:
             return "N/A"
 
-    def latest_active_program_location(self):
-        prg = self._latest_confirmed_non_future_program_role_grant()
-        if not prg:
-            return None
-        return prg.program_role.program.program_family.name
-
-    def latest_active_program_year(self):
-        prg = self._latest_confirmed_non_future_program_role_grant()
-        if not prg:
-            return None
-        return str(prg.program_role.program.start_date.year)
-
-    def confirmed_mentor_program_families(self):
-        """
-        Given that the Mentor Directory should not be empty,
-        When all programs in a program family have ended
-        We want to be able to show the mentors in the ended program
-        But when a program is active, we shouldn't show the confirmed
-        mentors of the ended program.
-        SubQueries were leveraged for optimisation to reduce
-        the number of queries.
-        """
-        prg = self._confirmed_non_future_program_role_grant()
-        program_ids = self._latest_program_id_foreach_program_family()
-        return list(prg.filter(
-            program_role__program__pk__in=program_ids
-        ).values_list(
-            'program_role__program__program_family__name',
-            flat=True).distinct())
-
-    def _latest_program_id_foreach_program_family(self):
-        ProgramFamily = swapper.load_model('accelerator', 'ProgramFamily')
-        latest_program_subquery = self._program_family__program_subquery()
-        return list(ProgramFamily.objects.annotate(
-            latest_program=Subquery(latest_program_subquery)
-        ).values_list("latest_program", flat=True))
-
-    def _program_family__program_subquery(self):
-        Program = swapper.load_model('accelerator', 'Program')
-        return Program.objects.filter(
-            program_family=OuterRef('pk'),
-            program_status__in=[ACTIVE_PROGRAM_STATUS, ENDED_PROGRAM_STATUS]
-        ).order_by("-created_at").values('pk')[:1]
-
-    def _latest_confirmed_non_future_program_role_grant(self):
-        prg = self._confirmed_non_future_program_role_grant()
-        return prg.order_by('-created_at').first()
-
-    def _confirmed_non_future_program_role_grant(self):
-        return self.user.programrolegrant_set.filter(
-            program_role__user_role__name=UserRole.MENTOR).exclude(
-            program_role__program__program_status__in=[
-                HIDDEN_PROGRAM_STATUS,
-                UPCOMING_PROGRAM_STATUS]
-        ).prefetch_related(
-            'program_role__program',
-            'program_role__program__program_family'
-        )
-
-    def is_confirmed_mentor(self):
-        return self.user.programrolegrant_set.filter(
-            program_role__user_role__name=UserRole.MENTOR).exists()
 
     @classmethod
     def mentors(cls, program):
@@ -391,17 +269,6 @@ class ExpertProfile(CoreProfile):
             filter['scenario__judging_round__in'] = active_rounds
         return filter
 
-    def office_hour_programs(self):
-        # returns a list of all active program ids associated with an expert
-        # having open office hours
-        has_available_office_hours = self.user.mentor_officehours.filter(
-            finalist__isnull=True,
-            start_date_time__gte=timezone.now()
-        ).exists()
-        if has_available_office_hours:
-            return list(_get_office_hour_holder_active_programs(self.user))
-        return []
-
 
 def _recruiting_judges():
     capacity = Q(capture_capacity=True)
@@ -409,17 +276,3 @@ def _recruiting_judges():
     return swapper.load_model('accelerator', 'JudgingRound').objects.filter(
         capacity | availability).exists()
 
-
-def _get_office_hour_holder_active_programs(user):
-    Clearance = swapper.load_model('accelerator', 'Clearance')
-    clearances = Clearance.objects.clearances_for_user(user).filter(
-        program_family__programs__program_status=ACTIVE_PROGRAM_STATUS
-    )
-    active_program_ids = set()
-    active_program_ids.update(list(clearances.values_list(
-        'program_family__programs__id', flat=True
-    ).distinct()))
-    active_program_ids.update(list(user.programrolegrant_set.filter(
-        OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM
-    ).values_list('program_role__program__id', flat=True).distinct()))
-    return active_program_ids

--- a/accelerator/models/expert_profile.py
+++ b/accelerator/models/expert_profile.py
@@ -12,7 +12,9 @@ from accelerator.utils import UserAlert
 from accelerator_abstract.models import (
     ACTIVE_PANEL_STATUS,
     CAPTURE_AVAILABILITY_DISABLED)
-from accelerator_abstract.models.base_judging_round import ONLINE_JUDGING_ROUND_TYPE
+from accelerator_abstract.models.base_judging_round import (
+    ONLINE_JUDGING_ROUND_TYPE,
+)
 
 CONFIRMED_FOR_MESSAGE = "<h4>%s, you are confirmed for %s:</h4>"
 EXPECTING_TO_SEE_YOU_MESSAGE = ("<p>&nbsp;</p><h4>We are expecting "
@@ -43,6 +45,7 @@ UPDATE_JUDGE_COMMITMENTS_NOTIFICATION = (
     'Update your judging commitments</a></b>'
     '<p>&nbsp;</p>'
 )
+SHORT_BIO_MAX_LENGTH = 140
 
 
 class ExpertProfile(CoreProfile):
@@ -191,7 +194,6 @@ class ExpertProfile(CoreProfile):
         else:
             return "N/A"
 
-
     @classmethod
     def mentors(cls, program):
         role_name = UserRole.MENTOR
@@ -275,4 +277,3 @@ def _recruiting_judges():
     availability = ~Q(capture_availability=CAPTURE_AVAILABILITY_DISABLED)
     return swapper.load_model('accelerator', 'JudgingRound').objects.filter(
         capacity | availability).exists()
-

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -261,6 +261,31 @@ class TestCoreProfile(TestCase):
         self.assertFalse(_user_is_alum_in_residence(
             air_program, non_air_program))
 
+    def test_finalist_profile_program_participation(self):
+        expected_programs = ['program0']
+        user = _user_with_role(
+            EntrepreneurFactory(), BaseUserRole.MENTOR, 'program0')
+        self.assertEqual(
+            list(user.coreprofile.program_participation()), expected_programs)
+
+    def test_mentor_profile_program_participation(self):
+        expected_programs = ['program1']
+        user = _user_with_role(
+            ExpertFactory(), BaseUserRole.MENTOR, 'program1')
+        self.assertEqual(
+            list(user.coreprofile.program_participation()), expected_programs)
+
+
+def _user_with_role(user, role_name, program_name):
+    role = UserRoleFactory(name=role_name)
+    program_role = ProgramRoleFactory.create(
+        user_role=role,
+        program=ProgramFactory(name=program_name))
+    ProgramRoleGrantFactory.create(
+        person=user,
+        program_role=program_role)
+    return user
+
 
 def _user_is_alum_in_residence(air_program=None, non_air_program=None):
     user = EntrepreneurFactory()

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -1,36 +1,35 @@
-# MIT License
-# Copyright (c) 2017 MassChallenge, Inc.
-
-from __future__ import unicode_literals
-
 from django.test import TestCase
 
-from accelerator.tests.factories import (
-    ClearanceFactory,
-    ExpertFactory,
-    EntrepreneurFactory,
-    EntrepreneurProfileFactory,
-    InterestCategoryFactory,
-    MemberFactory,
-    ProgramFactory,
-    ProgramRoleFactory,
-    ProgramRoleGrantFactory,
-    UserFactory,
-    UserRoleFactory,
-    ProgramFamilyFactory,
-    PartnerTeamMemberFactory,
-)
-from accelerator_abstract.models import (
-    BaseUserRole,
-    ENDED_PROGRAM_STATUS,
-)
 from accelerator.tests.contexts import (
     StartupTeamMemberContext,
     UserRoleContext,
 )
-from accelerator_abstract.models.base_clearance import (
-    CLEARANCE_LEVEL_STAFF,
+from accelerator.tests.factories import (
+    ClearanceFactory,
+    EntrepreneurFactory,
+    EntrepreneurProfileFactory,
+    ExpertFactory,
+    ExpertProfileFactory,
+    IndustryFactory,
+    InterestCategoryFactory,
+    MemberFactory,
+    MentorProgramOfficeHourFactory,
+    PartnerTeamMemberFactory,
+    ProgramFactory,
+    ProgramFamilyFactory,
+    ProgramRoleFactory,
+    ProgramRoleGrantFactory,
+    ProgramStartupStatusFactory,
+    StartupFactory,
+    StartupStatusFactory,
+    UserFactory,
+    UserRoleFactory,
 )
+from accelerator_abstract.models import (
+    ENDED_PROGRAM_STATUS,
+    BaseUserRole,
+)
+from accelerator_abstract.models.base_clearance import CLEARANCE_LEVEL_STAFF
 
 
 def expert(role):
@@ -281,6 +280,50 @@ class TestCoreProfile(TestCase):
         ClearanceFactory(user=user)
         self.assertEqual(user.coreprofile.roles(), expected)
 
+    def test_startup_name_function_returns_correct_value(self):
+        user = EntrepreneurFactory()
+        startup = _get_user_startup(user)
+        self.assertEqual(startup.name, user.coreprofile.startup_name())
+
+    def test_startup_industry_function_returns_correct_value(self):
+        user = EntrepreneurFactory()
+        startup = _get_user_startup(user)
+        self.assertEqual(
+            startup.primary_industry, user.coreprofile.startup_industry())
+
+    def test_startup_status_names_returns_correct_value(self):
+        user = EntrepreneurFactory()
+        status = ProgramStartupStatusFactory()
+        StartupStatusFactory(startup=_get_user_startup(user),
+                             program_startup_status=status)
+        self.assertEqual(
+            [status.startup_status], user.coreprofile.startup_status_names())
+
+    def test_top_level_startup_industry(self):
+        startup = StartupFactory(
+            primary_industry=IndustryFactory(parent=IndustryFactory()))
+        profile = StartupTeamMemberContext(
+            primary_contact=False, startup=startup).user.coreprofile
+        industry = startup.primary_industry
+        self.assertEqual(industry.parent,
+                         profile.top_level_startup_industry())
+
+    def test_office_hour_holder_in_active_gets_office_hour_programs(self):
+        program = ProgramFactory()
+        profile = ExpertProfileFactory()
+        UserRoleContext(
+            BaseUserRole.MENTOR, user=profile.user, program=program)
+        _create_office_hour(profile.user, program)
+        self.assertEqual([program.id], profile.office_hour_programs())
+
+    def test_non_office_hour_holder_gets_no_office_hour_programs(self):
+        profile = ExpertProfileFactory()
+        self.assertEqual([], profile.office_hour_programs())
+
+    def test_is_active_returns_correct_value(self):
+        profile = ExpertProfileFactory()
+        self.assertEqual(profile.is_active(), True)
+
 
 def _user_with_role(user, role_name, program_name):
     role = UserRoleFactory(name=role_name)
@@ -302,3 +345,12 @@ def _user_is_alum_in_residence(air_program=None, non_air_program=None):
     if program_of_interest:
         return user_profile.is_alum_in_residence(program_of_interest)
     return user_profile.is_alum_in_residence()
+
+
+def _create_office_hour(mentor, program):
+    MentorProgramOfficeHourFactory(
+        mentor=mentor, finalist=None, program=program)
+
+
+def _get_user_startup(user):
+    return StartupTeamMemberContext(user=user, primary_contact=False).startup

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -266,14 +266,20 @@ class TestCoreProfile(TestCase):
         user = _user_with_role(
             EntrepreneurFactory(), BaseUserRole.MENTOR, 'program0')
         self.assertEqual(
-            list(user.coreprofile.program_participation()), expected_programs)
+            user.coreprofile.program_participation(), expected_programs)
 
     def test_mentor_profile_program_participation(self):
         expected_programs = ['program1']
         user = _user_with_role(
             ExpertFactory(), BaseUserRole.MENTOR, 'program1')
         self.assertEqual(
-            list(user.coreprofile.program_participation()), expected_programs)
+            user.coreprofile.program_participation(), expected_programs)
+
+    def test_roles_function_returns_user_roles(self):
+        expected = [BaseUserRole.STAFF, BaseUserRole.ALUM]
+        user = _user_with_role(ExpertFactory(), BaseUserRole.ALUM, 'program2')
+        ClearanceFactory(user=user)
+        self.assertEqual(user.coreprofile.roles(), expected)
 
 
 def _user_with_role(user, role_name, program_name):

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -327,10 +327,10 @@ class TestCoreProfile(TestCase):
 
 def _user_with_role(user, role_name, program_name):
     role = UserRoleFactory(name=role_name)
-    program_role = ProgramRoleFactory.create(
+    program_role = ProgramRoleFactory(
         user_role=role,
         program=ProgramFactory(name=program_name))
-    ProgramRoleGrantFactory.create(
+    ProgramRoleGrantFactory(
         person=user,
         program_role=program_role)
     return user


### PR DESCRIPTION
## [AC-9028](https://masschallenge.atlassian.net/browse/AC-9028)

**Testing**
- - Visit [aloglia dev_community index](https://www.algolia.com/apps/3WW3PBJ1CW/explorer/browse/dev_community?searchMode=search)
- Confirm that the following conditions are satisfied:
  - Create an index for the Community directory

    - index on CoreProfile

    - index name is “Community”

    - index the same fields currently indexed for Mentor and People directories (union of the set)

    - prod, staging, and dev indexes (as we currently do for Mentor and People directories)

    - Filters will include Industry, Subindustry, Role (Finalist, Alumni, Mentor, Staff), Specialty (Investor, Executive, Lawyer), office hours availability

    - New filter: Program participation - user has Finalist or Confirmed Mentor role grant in an active program 

   - determine when this index needs to be updated and provide or recommend a mechanism for that 
       - `office_hour_programs`  field is updated (partial-reindex) when an OH session is created
       - `Coreprofile` model is automatically updated when a Create|Update|Delete action happens (functionality provided by `algoliasearch_django`)
      
[Sibling PR](https://github.com/masschallenge/accelerate/pull/3044)