### PR TITLE
[AC-9294] Update travis config to rebase on pull rather than merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ install:
 - echo $BRANCH
 - export CURRENT_HEAD=$(git rev-parse HEAD)
 - git checkout -b $DEFAULT_BRANCH || git checkout $DEFAULT_BRANCH
+- echo $DEFAULT_BRANCH
+- git config pull.rebase true
 - git pull origin $DEFAULT_BRANCH --no-edit
 - git checkout -b $BRANCH || git checkout $BRANCH
 - git pull origin $BRANCH --no-edit

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - echo $BRANCH
 - export CURRENT_HEAD=$(git rev-parse HEAD)
 - git checkout -b $DEFAULT_BRANCH || git checkout $DEFAULT_BRANCH
-- echo $DEFAULT_BRANCH
+- echo $DEFAULT_BRANCH 
 - git config pull.rebase true
 - git pull origin $DEFAULT_BRANCH --no-edit
 - git checkout -b $BRANCH || git checkout $BRANCH


### PR DESCRIPTION
This PR updates .travis.yml to use rebase rather than merge as the behavior on pull. It's hoped that this will clean up the inability to create passing PR builds. 