### PR TITLE
[AC-9365] Create a unified user sign-up interface

### DIFF
--- a/accelerator/tests/factories/__init__.py
+++ b/accelerator/tests/factories/__init__.py
@@ -127,3 +127,4 @@ from .partner_judging_round_challenge_factory import (
     PartnerJudgingRoundChallengeFactory,
 )
 from .community_participation_factory import CommunityParticipation
+from .core_profile_model_factory import CoreProfileModelFactory

--- a/accelerator/tests/factories/core_profile_model_factory.py
+++ b/accelerator/tests/factories/core_profile_model_factory.py
@@ -1,0 +1,7 @@
+from accelerator.models.core_profile import CoreProfile
+from accelerator.tests.factories import CoreProfileFactory
+
+
+class CoreProfileModelFactory(CoreProfileFactory):
+    class Meta:
+        model = CoreProfile

--- a/accelerator/tests/test_base_profile.py
+++ b/accelerator/tests/test_base_profile.py
@@ -1,8 +1,13 @@
 from __future__ import unicode_literals
 
+from django.db import IntegrityError
 from django.test import TestCase
 
-from accelerator.tests.factories import MemberFactory
+from accelerator.models import BaseProfile
+from accelerator.tests.factories import (
+    CoreProfileModelFactory,
+    MemberFactory,
+)
 
 
 class TestBaseProfile(TestCase):
@@ -21,3 +26,15 @@ class TestBaseProfile(TestCase):
         display = member.baseprofile.__str__()
         self.assertIn(member.email, display)
         self.assertNotIn(member.last_name, display)
+
+    def test_manager_doesnt_to_create_memberprofile_for_unified_profiles(self):
+        """
+        Base profile manager should no longer attempt to create member
+        profile objects for unified profile users. Attempting to create
+        a member profile will raise IntegrityError
+        """
+        profile = CoreProfileModelFactory(expert_interest=True)
+        try:
+            BaseProfile.objects.get(email=profile.user.email)
+        except IntegrityError:
+            self.fail('Unexpectedly raised IntegrityError')

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -6,6 +6,7 @@ from accelerator.tests.contexts import (
 )
 from accelerator.tests.factories import (
     ClearanceFactory,
+    CoreProfileModelFactory,
     EntrepreneurFactory,
     EntrepreneurProfileFactory,
     ExpertFactory,
@@ -349,6 +350,16 @@ class TestCoreProfile(TestCase):
         program = ProgramFactory(program_status=UPCOMING_PROGRAM_STATUS)
         _user_with_role(profile.user, BaseUserRole.MENTOR, program=program)
         self.assertTrue(profile.is_mentor_in_upcoming_program())
+
+    def test_users_with_expert_interest_get_experts_landing_page(self):
+        profile = CoreProfileModelFactory(expert_interest=True)
+        expected = '/dashboard/expert/overview/'
+        self.assertEqual(profile.check_landing_page(), expected)
+
+    def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
+        profile = CoreProfileModelFactory(entrepreneur_interest=True)
+        expected = 'applicant_homepage'
+        self.assertEqual(profile.check_landing_page(), expected)
 
     def was_mentor_in_last_12_months(self):
         profile = ExpertProfileFactory()


### PR DESCRIPTION
## [AC-9365](https://masschallenge.atlassian.net/browse/AC-9365)

**Changes introduced**
- created a unified user sign-up interface

**Testing**
- Visit `/accounts/register/`
- Confirm that the definition of done according to [AC-9365](https://masschallenge.atlassian.net/browse/AC-9365) is satisfied

Deploying to a test server ⌛ 