### PR TITLE
[AC-9340] Create Personal Profile progress bar

### DIFF
--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -42,6 +42,19 @@ OFFICE_HOURS_HOLDER = Q(
 ACTIVE_PROGRAM = Q(
     program_role__program__program_status=ACTIVE_PROGRAM_STATUS)
 
+PROFILE_USER_FIELDS = ['first_name', 'last_name']
+PROFILE_FIELDS = [
+    'shared_demographic_data', 'education_level', 'privacy_email',
+    'privacy_web', 'privacy_profile', 'primary_industry',
+    'functional_expertise', 'additional_industries', 'privacy_phone',
+    'linked_in_url', 'geographic_experience', 'program_families',
+    'authorization_to_share_ethno_racial_identity']
+PROFILE_LOCATION_FIELDS = [
+    'street_address', 'city', 'state', 'country']
+COMMUNITY_PARTICIPATION_TYPES = [
+    PARTICIPATION_ROLE, ADVISING_STARTUP_BUSINESS_AREA,
+    ADVISING_STARTUP_SUPPORT_BELIEVE]
+
 
 class CoreProfile(BaseCoreProfile, PolymorphicModel):
     class Meta(BaseCoreProfile.Meta):
@@ -395,32 +408,20 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
     @property
     def percent_complete(self):
         completed_count = 0
-        profile_user_fields = ['first_name', 'last_name']
-        profile_fields = [
-            'shared_demographic_data', 'education_level', 'privacy_email',
-            'privacy_web', 'privacy_profile', 'primary_industry',
-            'functional_expertise', 'additional_industries', 'privacy_phone',
-            'linked_in_url', 'geographic_experience', 'program_families',
-            'authorization_to_share_ethno_racial_identity']
-        profile_location_fields = [
-            'street_address', 'city', 'state', 'country']
-        community_participation_types = [
-            PARTICIPATION_ROLE, ADVISING_STARTUP_BUSINESS_AREA,
-            ADVISING_STARTUP_SUPPORT_BELIEVE]
-        profile_data_dict = model_to_dict(self, profile_fields)
-        user_data_dict = model_to_dict(self.user, profile_user_fields)
+        profile_data_dict = model_to_dict(self, PROFILE_FIELDS)
+        user_data_dict = model_to_dict(self.user, PROFILE_USER_FIELDS)
         completed_participation_by_type = self.community_participation.filter(
-            type__in=community_participation_types).values_list(
+            type__in=COMMUNITY_PARTICIPATION_TYPES).values_list(
             'type', flat=True).distinct().count()
         if self.user_location:
             location_data_dict = model_to_dict(
-                self.user_location, profile_location_fields)
+                self.user_location, PROFILE_LOCATION_FIELDS)
             completed_count += _get_completed_fields_count(location_data_dict)
         completed_count += _get_completed_fields_count(profile_data_dict)
         completed_count += _get_completed_fields_count(user_data_dict)
         completed_count += completed_participation_by_type
-        total = len(community_participation_types + profile_fields
-                    + profile_user_fields + profile_location_fields)
+        total = len(COMMUNITY_PARTICIPATION_TYPES + PROFILE_FIELDS
+                    + PROFILE_USER_FIELDS + PROFILE_LOCATION_FIELDS)
         return completed_count / total * 100
 
 

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -397,12 +397,13 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         completed_count = 0
         profile_user_fields = ['first_name', 'last_name']
         profile_fields = [
-            'shared_demographic_data', 'education_level',
+            'shared_demographic_data', 'education_level', 'privacy_email',
             'privacy_web', 'privacy_profile', 'primary_industry',
-            'functional_expertise', 'additional_industries',
-            'linked_in_url', 'geographic_experience', 'privacy_phone',
-            'privacy_email', 'authorization_to_share_ethno_racial_identity']
-        profile_location_fields = ['street_address', 'state', 'country']
+            'functional_expertise', 'additional_industries', 'privacy_phone',
+            'linked_in_url', 'geographic_experience', 'program_families',
+            'authorization_to_share_ethno_racial_identity']
+        profile_location_fields = [
+            'street_address', 'city', 'state', 'country']
         community_participation_types = [
             PARTICIPATION_ROLE, ADVISING_STARTUP_BUSINESS_AREA,
             ADVISING_STARTUP_SUPPORT_BELIEVE]

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -393,7 +393,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
                 program_role__user_role__name__in=roles).exists()
 
     @property
-    def profile_completion_percentage(self):
+    def percent_complete(self):
         completed_count = 0
         profile_user_fields = ['first_name', 'last_name']
         profile_fields = [

--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -1,4 +1,5 @@
 import swapper
+from django.forms import model_to_dict
 from pytz import utc
 from datetime import (
     datetime,
@@ -14,6 +15,11 @@ from django.utils import timezone
 from polymorphic.models import PolymorphicModel
 
 from accelerator.models import UserRole
+from accelerator.models.community_participation import (
+    ADVISING_STARTUP_BUSINESS_AREA,
+    ADVISING_STARTUP_SUPPORT_BELIEVE,
+    PARTICIPATION_ROLE,
+)
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     BIO_MAX_LENGTH,
@@ -386,6 +392,36 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
             return self.user.programrolegrant_set.filter(
                 program_role__user_role__name__in=roles).exists()
 
+    @property
+    def profile_completion_percentage(self):
+        completed_count = 0
+        profile_user_fields = ['first_name', 'last_name']
+        profile_fields = [
+            'shared_demographic_data', 'education_level',
+            'privacy_web', 'privacy_profile', 'primary_industry',
+            'functional_expertise', 'additional_industries',
+            'linked_in_url', 'geographic_experience', 'privacy_phone',
+            'privacy_email', 'authorization_to_share_ethno_racial_identity']
+        profile_location_fields = ['street_address', 'state', 'country']
+        community_participation_types = [
+            PARTICIPATION_ROLE, ADVISING_STARTUP_BUSINESS_AREA,
+            ADVISING_STARTUP_SUPPORT_BELIEVE]
+        profile_data_dict = model_to_dict(self, profile_fields)
+        user_data_dict = model_to_dict(self.user, profile_user_fields)
+        completed_participation_by_type = self.community_participation.filter(
+            type__in=community_participation_types).values_list(
+            'type', flat=True).distinct().count()
+        if self.user_location:
+            location_data_dict = model_to_dict(
+                self.user_location, profile_location_fields)
+            completed_count += _get_completed_fields_count(location_data_dict)
+        completed_count += _get_completed_fields_count(profile_data_dict)
+        completed_count += _get_completed_fields_count(user_data_dict)
+        completed_count += completed_participation_by_type
+        total = len(community_participation_types + profile_fields
+                    + profile_user_fields + profile_location_fields)
+        return completed_count / total * 100
+
 
 def _get_office_hour_holder_active_programs(user):
     Clearance = swapper.load_model('accelerator', 'Clearance')
@@ -406,5 +442,15 @@ def _get_completed_application_count(
     if assignment_completed:
         form = forms.get(str(application.pk), None)
         if form and form.feedback_status != 'INCOMPLETE':
+            completed_count += 1
+    return completed_count
+
+
+def _get_completed_fields_count(model_data_dict):
+    valid_negatives = (False,)
+    completed_count = 0
+    for field in model_data_dict:
+        data = model_data_dict[field]
+        if data or data in valid_negatives:
             completed_count += 1
     return completed_count

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -21,6 +21,7 @@ from accelerator.tests.factories import (
     MentorProgramOfficeHourFactory,
     PartnerTeamMemberFactory,
     ProgramFactory,
+    ProgramFamilyFactory,
     ProgramRoleFactory,
     ProgramRoleGrantFactory,
     ProgramStartupStatusFactory,
@@ -376,16 +377,17 @@ class TestCoreProfile(TestCase):
         self.assertTrue(profile.was_mentor_in_last_12_months())
 
     def test_completion_percentage_is_correct_for_completed_profile(self):
-        participations = [CommunityParticipationFactory(type=type[0])
-                          for type in PARTICIPATION_CHOICES]
+        participation = [CommunityParticipationFactory(type=type[0])
+                         for type in PARTICIPATION_CHOICES]
         profile = ExpertProfileFactory(
             education_level=EDUCATIONAL_LEVEL_CHOICES[-1][0],
             additional_industries=[IndustryFactory()],
             functional_expertise=[FunctionalExpertiseFactory()],
             geographic_experience=[GeographicExperienceFactory()],
+            program_families=[ProgramFamilyFactory()],
             primary_industry=IndustryFactory(),
-            community_participation=participations)
-        completion_percentage = profile.profile_completion_percentage
+            community_participation=participation)
+        completion_percentage = profile.percent_complete
         self.assertEqual(completion_percentage, 100.0)
 
 

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -390,6 +390,13 @@ class TestCoreProfile(TestCase):
         completion_percentage = profile.percent_complete
         self.assertEqual(completion_percentage, 100.0)
 
+    def test_completion_percentage_is_correct_for_incomplete_profile(self):
+        # missing 7/22 fields used to calculate profile completion %
+        profile = ExpertProfileFactory(
+            program_families=[ProgramFamilyFactory()])
+        rounded_percent = round(profile.percent_complete, 2)
+        self.assertEqual(rounded_percent, 68.18)
+
 
 def _user_with_role(user, role_name, program_name='program0', program=None):
     role = UserRoleFactory(name=role_name)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -1,16 +1,20 @@
 from django.test import TestCase
 
+from accelerator.models.community_participation import PARTICIPATION_CHOICES
 from accelerator.tests.contexts import (
     StartupTeamMemberContext,
     UserRoleContext,
 )
 from accelerator.tests.factories import (
     ClearanceFactory,
+    CommunityParticipationFactory,
     CoreProfileModelFactory,
     EntrepreneurFactory,
     EntrepreneurProfileFactory,
     ExpertFactory,
     ExpertProfileFactory,
+    FunctionalExpertiseFactory,
+    GeographicExperienceFactory,
     IndustryFactory,
     InterestCategoryFactory,
     MemberFactory,
@@ -33,6 +37,9 @@ from accelerator_abstract.models import (
     BaseUserRole,
 )
 from accelerator_abstract.models.base_clearance import CLEARANCE_LEVEL_STAFF
+from accelerator_abstract.models.base_core_profile import (
+    EDUCATIONAL_LEVEL_CHOICES,
+)
 
 
 def expert(role):
@@ -367,6 +374,19 @@ class TestCoreProfile(TestCase):
                                  end_date=months_from_now(-12))
         _user_with_role(profile.user, BaseUserRole.MENTOR, program=program)
         self.assertTrue(profile.was_mentor_in_last_12_months())
+
+    def test_completion_percentage_is_correct_for_completed_profile(self):
+        participations = [CommunityParticipationFactory(type=type[0])
+                          for type in PARTICIPATION_CHOICES]
+        profile = ExpertProfileFactory(
+            education_level=EDUCATIONAL_LEVEL_CHOICES[-1][0],
+            additional_industries=[IndustryFactory()],
+            functional_expertise=[FunctionalExpertiseFactory()],
+            geographic_experience=[GeographicExperienceFactory()],
+            primary_industry=IndustryFactory(),
+            community_participation=participations)
+        completion_percentage = profile.profile_completion_percentage
+        self.assertEqual(completion_percentage, 100.0)
 
 
 def _user_with_role(user, role_name, program_name='program0', program=None):


### PR DESCRIPTION
## [AC-9340](https://masschallenge.atlassian.net/browse/AC-9340)

**Changes introduced**
- add percent_complete function to get profile completion progress in %

**Testing**
- Visit any of the unified profile views e.g https://test-cam.masschallenge.org/profile/ 
- Confirm that the definition of done according to [AC-9340](https://masschallenge.atlassian.net/browse/AC-9340) is satisfied

[Sibling PR](https://github.com/masschallenge/accelerate/pull/3196)