### PR TITLE
[AC-9402] Default redirect for entrepreneur users should be /profile

### DIFF
--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -368,15 +368,15 @@ class TestCoreProfile(TestCase):
         'activate_unified_profile_views', False))        
     def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
-        expected = 'profile'
+        expected = 'applicant_homepage'
         self.assertEqual(profile.check_landing_page(), expected)
-
+        
     @patch(flag_smith_has_feature, fake_flag_smith_response(
         'activate_unified_profile_views', True))
     def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'profile'
-        self.assertEqual(profile.check_landing_p[Oage(), expected)        
+        self.assertEqual(profile.check_landing_page(), expected)    
 
     def was_mentor_in_last_12_months(self):
         profile = ExpertProfileFactory()

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -377,8 +377,7 @@ class TestCoreProfile(TestCase):
         self.assertEqual(profile.check_landing_page(), expected)
         
     @patch("bullet_train.BulletTrain.feature_enabled", return_value=True)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=False)    
-        'activate_unified_profile_views', True))
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
     def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'profile'

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -368,15 +368,16 @@ class TestCoreProfile(TestCase):
         profile = CoreProfileModelFactory(expert_interest=True)
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
-
-    @patch('flag_smith_has_feature', fake_flag_smith_response(
-        'activate_unified_profile_views', False))        
+        
+    @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)    
     def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'applicant_homepage'
         self.assertEqual(profile.check_landing_page(), expected)
         
-    @patch('flag_smith_has_feature', fake_flag_smith_response(
+    @patch("bullet_train.BulletTrain.feature_enabled", return_value=True)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)    
         'activate_unified_profile_views', True))
     def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -35,6 +35,7 @@ from accelerator.tests.utils import (
     fake_flag_smith_response,
     months_from_now,
 )
+from accelerator.utils import flag_smith_has_feature
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -32,10 +32,8 @@ from accelerator.tests.factories import (
     UserRoleFactory,
 )
 from accelerator.tests.utils import (
-    fake_flag_smith_response,
     months_from_now,
 )
-from accelerator.utils import flag_smith_has_feature
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
@@ -177,7 +175,9 @@ class TestCoreProfile(TestCase):
         profile = context.user.get_profile()
         self.assertTrue(profile.role_based_landing_page() == page)
 
-    def test_role_based_landing_page_excluding_roles(self):
+    @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
+    def test_role_based_landing_page_excluding_roles(self, *args):
         page = "/asante"
         context = StartupTeamMemberContext(
             primary_contact=False)
@@ -261,7 +261,9 @@ class TestCoreProfile(TestCase):
         landing_page = user_profile.check_landing_page()
         self.assertEqual(landing_page, test_landing_page)
 
-    def test_landing_page_if_profile_landing_page_is_set_to_home(self):
+    @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
+    def test_landing_page_if_profile_landing_page_is_set_to_home(self, *args):
         user_profile = EntrepreneurProfileFactory(landing_page="/")
         landing_page = user_profile.check_landing_page()
         self.assertEqual(landing_page, user_profile.default_page)
@@ -368,20 +370,22 @@ class TestCoreProfile(TestCase):
         profile = CoreProfileModelFactory(expert_interest=True)
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
-        
+
     @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=False)    
-    def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
+    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
+    def test_user_with_entrepreneur_interest_get_startups_landing_page(self,
+                                                                       *args):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'applicant_homepage'
         self.assertEqual(profile.check_landing_page(), expected)
-        
+
     @patch("bullet_train.BulletTrain.feature_enabled", return_value=True)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
-    def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
+    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
+    def test_user_with_entrepreneur_interest_get_profile_landing_page(self,
+                                                                      *args):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'profile'
-        self.assertEqual(profile.check_landing_page(), expected)    
+        self.assertEqual(profile.check_landing_page(), expected)
 
     def was_mentor_in_last_12_months(self):
         profile = ExpertProfileFactory()

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -364,9 +364,9 @@ class TestCoreProfile(TestCase):
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
 
-    def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
+    def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
-        expected = 'applicant_homepage'
+        expected = 'profile'
         self.assertEqual(profile.check_landing_page(), expected)
 
     def was_mentor_in_last_12_months(self):

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -364,10 +364,19 @@ class TestCoreProfile(TestCase):
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
 
-    def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
+    @patch(flag_smith_has_feature, fake_flag_smith_response(
+        'activate_unified_profile_views', False))        
+    def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'profile'
         self.assertEqual(profile.check_landing_page(), expected)
+
+    @patch(flag_smith_has_feature, fake_flag_smith_response(
+        'activate_unified_profile_views', True))
+    def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
+        profile = CoreProfileModelFactory(entrepreneur_interest=True)
+        expected = 'profile'
+        self.assertEqual(profile.check_landing_p[Oage(), expected)        
 
     def was_mentor_in_last_12_months(self):
         profile = ExpertProfileFactory()

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -369,14 +369,14 @@ class TestCoreProfile(TestCase):
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
 
-    @patch(flag_smith_has_feature, fake_flag_smith_response(
+    @patch('flag_smith_has_feature', fake_flag_smith_response(
         'activate_unified_profile_views', False))        
     def test_users_with_entrepreneur_interest_get_startups_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
         expected = 'applicant_homepage'
         self.assertEqual(profile.check_landing_page(), expected)
         
-    @patch(flag_smith_has_feature, fake_flag_smith_response(
+    @patch('flag_smith_has_feature', fake_flag_smith_response(
         'activate_unified_profile_views', True))
     def test_users_with_entrepreneur_interest_get_profile_as_landing_page(self):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from mock import patch
 
 from accelerator.models.community_participation import PARTICIPATION_CHOICES
 from accelerator.tests.contexts import (

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -31,7 +31,10 @@ from accelerator.tests.factories import (
     UserFactory,
     UserRoleFactory,
 )
-from accelerator.tests.utils import months_from_now
+from accelerator.tests.utils import (
+    fake_flag_smith_response,
+    months_from_now,
+)
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,

--- a/accelerator/tests/utils.py
+++ b/accelerator/tests/utils.py
@@ -96,3 +96,9 @@ def find_row(rows, header, value):
         if row[header] == value:
             return row
     return None
+
+def fake_flag_smith_response(feature_of_interest, feature_on):
+    def fake_feature_check(feature_to_check):
+        return feature_on == (feature_to_check == feature_of_interest)
+
+    return fake_feature_check

--- a/accelerator/tests/utils.py
+++ b/accelerator/tests/utils.py
@@ -96,9 +96,3 @@ def find_row(rows, header, value):
         if row[header] == value:
             return row
     return None
-
-def fake_flag_smith_response(feature_of_interest, feature_on):
-    def fake_feature_check(feature_to_check):
-        return feature_on == (feature_to_check == feature_of_interest)
-
-    return fake_feature_check

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -138,7 +138,6 @@ LANDING_PAGE_MAP = {
 }
 
 
-
 class BaseCoreProfile(AcceleratorModel):
     user = models.OneToOneField(settings.AUTH_USER_MODEL,
                                 on_delete=models.CASCADE)

--- a/accelerator_abstract/models/base_core_profile.py
+++ b/accelerator_abstract/models/base_core_profile.py
@@ -28,6 +28,7 @@ from accelerator_abstract.models.base_program import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
 )
+from accelerator.utils import flag_smith_has_feature
 
 INVITED_JUDGE_ALERT = (
     "<h4>{first_name}, we would like to invite you to be a judge at "
@@ -124,6 +125,18 @@ GEOGRAPHIC_EXPERIENCE_HELP_TEXT = (
     mark_safe('You may select up to 5 regions. To select multiple '
               'regions, please press and hold Control (CTRL) on PCs '
               'or Command (&#8984;) on Macs'))
+
+
+# Delete when removing CAM V feature flag
+OLD_LANDING_PAGE_MAP = {
+    EXPERT_USER_TYPE: 'expert_homepage',
+    ENTREPRENEUR_USER_TYPE: 'applicant_homepage',
+}
+LANDING_PAGE_MAP = {
+    EXPERT_USER_TYPE: 'expert_homepage',
+    ENTREPRENEUR_USER_TYPE: 'profile',
+}
+
 
 
 class BaseCoreProfile(AcceleratorModel):
@@ -611,11 +624,11 @@ class BaseCoreProfile(AcceleratorModel):
 
     @property
     def user_default_page(self):
-        url_map = {
-            EXPERT_USER_TYPE: 'expert_homepage',
-            ENTREPRENEUR_USER_TYPE: 'applicant_homepage',
-        }
+        if flag_smith_has_feature('activate_unified_profile_views'):
+            url_map = LANDING_PAGE_MAP
+        else:
+            url_map = OLD_LANDING_PAGE_MAP
         try:
-            return url_map[self.participation]
+            return url_map[self.participation.upper()]
         except KeyError:
             return self.default_page


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-9402

To review: on a local machine pointing to a flagsmith environment with feature flag "activate_unified_profile_views" set to true, become an entrepreneur user (on clean db, user 93049 is an example)
when visiting localhost:8181/ you should be redirected to /profile, _not_ to /applicant