### PR TITLE
[AC-9401] Profile percent complete function improvements

### DIFF
--- a/accelerator/models/core_profile.py
+++ b/accelerator/models/core_profile.py
@@ -405,7 +405,6 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
             return self.user.programrolegrant_set.filter(
                 program_role__user_role__name__in=roles).exists()
 
-    @property
     def percent_complete(self):
         completed_count = 0
         profile_data_dict = model_to_dict(self, PROFILE_FIELDS)
@@ -422,7 +421,7 @@ class CoreProfile(BaseCoreProfile, PolymorphicModel):
         completed_count += completed_participation_by_type
         total = len(COMMUNITY_PARTICIPATION_TYPES + PROFILE_FIELDS
                     + PROFILE_USER_FIELDS + PROFILE_LOCATION_FIELDS)
-        return completed_count / total * 100
+        return round(completed_count / total, 2)
 
 
 def _get_office_hour_holder_active_programs(user):

--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -387,15 +387,14 @@ class TestCoreProfile(TestCase):
             program_families=[ProgramFamilyFactory()],
             primary_industry=IndustryFactory(),
             community_participation=participation)
-        completion_percentage = profile.percent_complete
-        self.assertEqual(completion_percentage, 100.0)
+        completion_percentage = profile.percent_complete()
+        self.assertEqual(completion_percentage, 1)
 
     def test_completion_percentage_is_correct_for_incomplete_profile(self):
         # missing 7/22 fields used to calculate profile completion %
         profile = ExpertProfileFactory(
             program_families=[ProgramFamilyFactory()])
-        rounded_percent = round(profile.percent_complete, 2)
-        self.assertEqual(rounded_percent, 68.18)
+        self.assertEqual(profile.percent_complete(), 0.68)
 
 
 def _user_with_role(user, role_name, program_name='program0', program=None):


### PR DESCRIPTION
## [AC-9401](https://masschallenge.atlassian.net/browse/AC-9401)

**Testing**
- Confirm the following conditions are satisfied:
   - The percent_complete property should be converted to a function to allow new parameters in the future
   - The percent_complete function should return a number between zero and 1 (inclusive)
- Personal Profile progress bar should continue to work as expected

[Sibling PR](url)