### PR TITLE
[AC-9535] Include revised program interest in Personal Profile progress calculation

### DIFF
--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -395,7 +395,7 @@ class TestCoreProfile(TestCase):
         self.assertTrue(profile.was_mentor_in_last_12_months())
 
     @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
     def test_completion_percentage_is_correct_for_completed_profile(self,
                                                                     *args):
         participation = [CommunityParticipationFactory(type=type[0])
@@ -429,13 +429,13 @@ class TestCoreProfile(TestCase):
         self.assertEqual(completion_percentage, 1)
 
     @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=False)
+    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
     def test_completion_percentage_is_correct_for_incomplete_profile(self,
                                                                      *args):
         # missing 7/22 fields used to calculate profile completion %
         profile = ExpertProfileFactory(
             program_families=[ProgramFamilyFactory()])
-        self.assertEqual(profile.percent_complete(), 0.67)
+        self.assertEqual(profile.percent_complete(), 0.68)
 
 
 def _user_with_role(user, role_name, program_name='program0', program=None):


### PR DESCRIPTION
## [AC-9535](https://masschallenge.atlassian.net/browse/AC-9535)

**Changes introduced**
- add `program_interest` field as part of the  get profile completion progress computation

**Testing**
- Confirm that the definition of done according to [AC-9535](https://masschallenge.atlassian.net/browse/AC-9635) is satisfied

[Sibling PR](https://github.com/masschallenge/accelerate/pull/3268)