### PR TITLE
[AC-9609] Switch flagsmith source to use PyPi rather than github

### DIFF
--- a/accelerator/tests/test_core_profile.py
+++ b/accelerator/tests/test_core_profile.py
@@ -345,8 +345,8 @@ class TestCoreProfile(TestCase):
         expected = '/dashboard/expert/overview/'
         self.assertEqual(profile.check_landing_page(), expected)
 
-    @patch("bullet_train.BulletTrain.feature_enabled", return_value=True)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
+    @patch("flagsmith.Flagsmith.feature_enabled", return_value=True)
+    @patch("flagsmith.Flagsmith.has_feature", return_value=True)
     def test_user_with_entrepreneur_interest_get_profile_landing_page(self,
                                                                       *args):
         profile = CoreProfileModelFactory(entrepreneur_interest=True)
@@ -360,8 +360,8 @@ class TestCoreProfile(TestCase):
         _user_with_role(profile.user, BaseUserRole.MENTOR, program=program)
         self.assertTrue(profile.was_mentor_in_last_12_months())
 
-    @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
+    @patch("flagsmith.Flagsmith.feature_enabled", return_value=False)
+    @patch("flagsmith.Flagsmith.has_feature", return_value=True)
     def test_completion_percentage_is_correct_for_completed_profile(self,
                                                                     *args):
         participation = [CommunityParticipationFactory(type=type[0])
@@ -377,8 +377,8 @@ class TestCoreProfile(TestCase):
         completion_percentage = profile.percent_complete()
         self.assertEqual(completion_percentage, 1)
 
-    @patch("bullet_train.BulletTrain.feature_enabled", return_value=True)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
+    @patch("flagsmith.Flagsmith.feature_enabled", return_value=True)
+    @patch("flagsmith.Flagsmith.has_feature", return_value=True)
     def test_program_family_not_required_when_feature_flag_is_on(self,
                                                                  *args):
         participation = [CommunityParticipationFactory(type=type[0])
@@ -394,8 +394,8 @@ class TestCoreProfile(TestCase):
         completion_percentage = profile.percent_complete()
         self.assertEqual(completion_percentage, 1)
 
-    @patch("bullet_train.BulletTrain.feature_enabled", return_value=False)
-    @patch("bullet_train.BulletTrain.has_feature", return_value=True)
+    @patch("flagsmith.Flagsmith.feature_enabled", return_value=False)
+    @patch("flagsmith.Flagsmith.has_feature", return_value=True)
     def test_completion_percentage_is_correct_for_incomplete_profile(self,
                                                                      *args):
         # missing 7/22 fields used to calculate profile completion %

--- a/accelerator/tests/test_utils.py
+++ b/accelerator/tests/test_utils.py
@@ -6,6 +6,6 @@ from ..utils import flag_smith_has_feature
 
 class TestUtils(TestCase):
     def test_flag_smith_has_feature(self):
-        with patch("bullet_train.BulletTrain.has_feature") as mock_function:
+        with patch("flagsmith.Flagsmith.has_feature") as mock_function:
             flag_smith_has_feature("feature_key")
             mock_function.assert_called_with("feature_key")

--- a/accelerator/utils.py
+++ b/accelerator/utils.py
@@ -1,4 +1,4 @@
-from bullet_train import BulletTrain
+from flagsmith import Flagsmith
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Permission
 from django.conf import settings
@@ -23,10 +23,10 @@ def flag_smith_has_feature(feature_name):
         flag_smith_key = settings.FLAG_SMITH_API_KEY.strip('"')
     else:
         flag_smith_key = ''
-    bt = BulletTrain(environment_id=flag_smith_key)
-    if bt:
-        if bt.has_feature(feature_name):
-            return bt.feature_enabled(feature_name)
+    flag_smith = Flagsmith(environment_id=flag_smith_key)
+    if flag_smith:
+        if flag_smith.has_feature(feature_name):
+            return flag_smith.feature_enabled(feature_name)
     return False
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-gdimport os
+import os
 
 from setuptools import find_packages, setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import os
+gdimport os
 
 from setuptools import find_packages, setup
 
@@ -25,7 +25,7 @@ INSTALL_REQUIRES = [
     "django-fluent-pages==2.0.6",
     "django-polymorphic",
     "django-sitetree",
-    "bullet-train",
+    "flagsmith==2.0.1",
     "mysqlclient",
     "django-polymorphic",
 ]


### PR DESCRIPTION
## [AC-9609](https://masschallenge.atlassian.net/browse/AC-9609)

**Changes introduced**
- use flagsmith from PyPi

**Testing**
- On django-accelerator and accelerate: git checkout to AC-9609,  make build and runserver
- Confirm that flagsmith continues to work as expected
- Confirm that the def of done according to [AC-9609](https://masschallenge.atlassian.net/browse/AC-9609) is satisfied

[Sibling PR](https://github.com/masschallenge/accelerate/pull/3360)

**Notes**
We have pinned flagsmith to version  [2.0.1](https://pypi.org/project/flagsmith/3.0.1/). The latest flagsmith version [3.0.1](https://pypi.org/project/flagsmith/2.0.1/) only supports  Python >=3.7.0, <4. 

[AC-9691](https://masschallenge.atlassian.net/browse/AC-9691) will upgrade flagsmith to the latest version once we upgrade our python version